### PR TITLE
docs: add license, readme, and adrs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arif Iqbal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ docker compose up
 
 ---
 
-## Features
+## What FlowMesh Is
 
-### Community Edition — free, open source, always
+Open source. Self-hosted. Free forever. No license keys. No feature flags. No artificial limits on events or destinations.
+
+Clone the repo, run one command, and have a full production event pipeline in 60 seconds. That is it.
+
+## Features
 
 | Feature | Status |
 |---|---|
@@ -42,22 +46,19 @@ docker compose up
 | Dead letter queue with one-click replay | 🔧 In development |
 | Real-time event dashboard | 🔧 In development |
 | Visual pipeline builder UI | 🔧 In development |
-| Basic alerting rules | 🔧 In development |
-| Single workspace | 🔧 In development |
+| Alerting engine | 🔧 In development |
 | Docker Compose deployment | ✅ Available |
-| REST API | ✅ Available |
+| Kubernetes Helm chart | 🔧 In development |
 | Node.js SDK | 🔧 In development |
 | Go SDK | 🔧 In development |
 
-### Enterprise Edition — paid license
+## Deployment
 
-- Multiple workspaces and organizations
-- SSO / SAML authentication
-- Fine-grained RBAC and audit logs
-- Kubernetes Helm chart with auto-scaling
-- Advanced rate limiting tiers
-- Custom destination plugins
-- SLA-based priority support
+**Docker Compose** — for solo developers and small teams. One server, one command. Runs comfortably on an $11/month Hetzner VPS.
+
+**Kubernetes + Helm** — for larger teams who want to self-host at scale with independent scaling per service. Also free and open source — we ship the Helm chart so you have the tools to do it properly.
+
+Both deployment options are fully open source with no restrictions.
 
 ---
 
@@ -323,7 +324,7 @@ All significant architectural decisions are documented in [`docs/adr/`](docs/adr
 - Why Go for the delivery service
 - Why two Redis instances
 - Database-per-service strategy (schema isolation in PostgreSQL)
-- Open core model — Community vs Enterprise
+- Open core model — self-hosted community vs FlowMesh Cloud
 
 ---
 
@@ -350,20 +351,28 @@ Please open an issue before starting significant work so we can discuss the appr
 
 ---
 
+## FlowMesh Cloud
+
+If you want FlowMesh without managing the infrastructure yourself, [FlowMesh Cloud](https://getflowmesh.com) is a hosted version — same pipeline, same SDK, no server to run.
+
+The self-hosted open source version has no limitations. FlowMesh Cloud is for teams who prefer not to operate it themselves.
+
+---
+
 ## Roadmap
 
 ### Phase 1 — Core pipeline (current)
 Ingestion → RabbitMQ → Pipeline → Go Delivery → destinations → DLQ.
-All distributed systems patterns implemented: rate limiting, idempotency, circuit breaker, backoff retry, dead letter queue.
+All distributed systems patterns: rate limiting, idempotency, circuit breaker, backoff retry, dead letter queue.
 
 ### Phase 2 — Dashboard
 Real-time event feed (WebSocket + Redis pub/sub), visual pipeline builder (React Flow), events explorer, DLQ replay UI.
 
 ### Phase 3 — Platform features
-Multi-tenancy, workspaces, API keys, RBAC, alerting engine, usage quotas.
+Auth, API keys, alerting engine, complete destination library.
 
-### Phase 4 — Enterprise edition
-SSO/SAML, audit logs, Kubernetes Helm chart, custom destination plugins.
+### Phase 4 — Kubernetes
+Helm chart for teams self-hosting at scale. Independent scaling per service.
 
 ### Phase 5 — Launch
 One-command Docker Compose, documentation site, Hacker News and Product Hunt launch.


### PR DESCRIPTION
## Summary

- Add MIT License file
- Rewrite README to reflect the correct model — self-hosted, free forever, no enterprise license keys, Docker Compose + Kubernetes both open source
- Remove premature "Enterprise Edition — paid license" section
- Add FlowMesh Cloud mention (hosted version exists, no pricing details)
- Move ADRs 001–008 from private root repo into public repo (`docs/adr/`)
- Add architecture diagram screenshot

## What changed in the README

- Replaced "Enterprise Edition — paid license" with a clean deployment section covering Docker Compose and Kubernetes Helm chart (both free)
- Added "FlowMesh Cloud" section — one paragraph, no pricing, just acknowledges the hosted option exists
- Roadmap updated to reflect actual phases (no "Enterprise edition" phase in public repo)

## ADRs added

| ADR | Decision |
|---|---|
| 001 | RabbitMQ over Kafka |
| 002 | Go for Delivery service |
| 003 | Two Redis instances (ephemeral + persistent) |
| 004 | PgBouncer for connection pooling |
| 005 | Open core model |
| 006 | Turborepo + pnpm monorepo |
| 007 | Prisma over TypeORM |
| 008 | Schema-per-service database isolation |

## Test plan

- [ ] README renders correctly on GitHub
- [ ] LICENSE file visible on GitHub repo page
- [ ] Architecture image loads in README
- [ ] ADR files readable in `docs/adr/`