### PR TITLE
feat(gateway): api gateway with jwt/api-key auth and rate limiting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,11 @@ auth-migrate:
 auth-generate:
 	pnpm --filter @flowmesh/auth prisma:generate
 
+# ─── API Gateway service ─────────────────────────────────────────────────────
+
+gateway-dev:
+	pnpm --filter @flowmesh/api-gateway dev
+
 # ─── Testing ─────────────────────────────────────────────────────────────────
 
 test:
@@ -140,4 +145,5 @@ env-setup:
         pipeline-dev pipeline-migrate-create pipeline-migrate pipeline-generate \
         config-dev config-migrate-create config-migrate config-generate gen-encryption-key \
         auth-dev auth-migrate-create auth-migrate auth-generate \
+        gateway-dev \
         test test-integration test-coverage test-watch install gen-jwt-secret env-setup

--- a/apps/api-gateway/nest-cli.json
+++ b/apps/api-gateway/nest-cli.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@flowmesh/api-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "nest build",
+    "dev": "nest start --watch",
+    "start": "node dist/main.js",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@flowmesh/nestjs-common": "workspace:*",
+    "@nestjs/axios": "^3.0.2",
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/config": "^4.0.4",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/jwt": "^10.2.0",
+    "@nestjs/platform-express": "^10.3.0",
+    "axios": "^1.6.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "ioredis": "^5.3.2",
+    "joi": "^18.1.2",
+    "nestjs-pino": "^3.5.0",
+    "pino": "8",
+    "pino-http": "^8.6.1",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.0",
+    "@nestjs/testing": "^10.3.0",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.0",
+    "pino-pretty": "^10.3.1",
+    "typescript": "^5.3.0"
+  }
+}

--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -1,0 +1,51 @@
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common'
+import { LoggerModule } from 'nestjs-pino'
+import { AppConfigModule } from './config/config.module'
+import { RedisModule } from './redis/redis.module'
+import { IngestModule } from './ingest/ingest.module'
+import { ManagementModule } from './management/management.module'
+import {
+  HealthModule,
+  HttpExceptionFilter,
+  CorrelationIdMiddleware,
+  CORRELATION_ID_HEADER,
+  CacheKeyModule,
+} from '@flowmesh/nestjs-common'
+
+const isDev = process.env.NODE_ENV !== 'production'
+
+@Module({
+  imports: [
+    AppConfigModule,
+    LoggerModule.forRoot({
+      pinoHttp: {
+        level: isDev ? 'debug' : 'info',
+        transport: isDev
+          ? { target: 'pino-pretty', options: { colorize: true, singleLine: true } }
+          : undefined,
+        serializers: {
+          req: (req) => ({ method: req.method, url: req.url }),
+          res: (res) => ({ statusCode: res.statusCode }),
+        },
+        customProps: (req) => ({
+          service: 'api-gateway',
+          correlationId: req.headers[CORRELATION_ID_HEADER],
+        }),
+        autoLogging: {
+          ignore: (req) => req.url === '/health',
+        },
+      },
+    }),
+    CacheKeyModule.forRoot({ service: 'gateway' }),
+    RedisModule,
+    IngestModule,
+    ManagementModule,
+    HealthModule,
+  ],
+  providers: [HttpExceptionFilter],
+})
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*')
+  }
+}

--- a/apps/api-gateway/src/auth/auth.guard.spec.ts
+++ b/apps/api-gateway/src/auth/auth.guard.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common'
+import { JwtService } from '@nestjs/jwt'
+import { ConfigService } from '@nestjs/config'
+import { AuthGuard } from './auth.guard'
+import { RedisService } from '../redis/redis.service'
+import { ProxyService } from '../proxy/proxy.service'
+
+const makeJwt = () => ({ verify: vi.fn() }) as unknown as JwtService
+const makeConfig = () => ({
+  get: vi.fn().mockReturnValue('test-jwt-secret'),
+}) as unknown as ConfigService
+const makeRedis = () => ({
+  isJtiBlacklisted: vi.fn().mockResolvedValue(false),
+  isApiKeyBlacklisted: vi.fn().mockResolvedValue(false),
+}) as unknown as RedisService
+const makeProxy = () => ({
+  validateApiKey: vi.fn().mockResolvedValue('ws-uuid-1'),
+}) as unknown as ProxyService
+
+const makeContext = (headers: Record<string, string>): ExecutionContext => {
+  const request: Record<string, unknown> = { headers }
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => ({}),
+    }),
+  } as unknown as ExecutionContext
+}
+
+describe('AuthGuard', () => {
+  let jwt: ReturnType<typeof makeJwt>
+  let config: ReturnType<typeof makeConfig>
+  let redis: ReturnType<typeof makeRedis>
+  let proxy: ReturnType<typeof makeProxy>
+  let guard: AuthGuard
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    jwt = makeJwt()
+    config = makeConfig()
+    redis = makeRedis()
+    proxy = makeProxy()
+    guard = new AuthGuard(jwt, config, redis, proxy)
+  })
+
+  describe('JWT auth', () => {
+    it('allows request with valid Bearer token', async () => {
+      vi.mocked(jwt.verify).mockReturnValue({
+        sub: 'user-1', workspaceId: 'ws-1', type: 'access', jti: 'jti-1',
+      } as never)
+
+      const ctx = makeContext({ authorization: 'Bearer valid.token' })
+      const result = await guard.canActivate(ctx)
+
+      expect(result).toBe(true)
+      const req = ctx.switchToHttp().getRequest() as any
+      expect(req.auth).toEqual({ userId: 'user-1', workspaceId: 'ws-1' })
+    })
+
+    it('throws when token is blacklisted', async () => {
+      vi.mocked(jwt.verify).mockReturnValue({
+        sub: 'user-1', workspaceId: 'ws-1', type: 'access', jti: 'jti-1',
+      } as never)
+      vi.mocked(redis.isJtiBlacklisted).mockResolvedValue(true)
+
+      const ctx = makeContext({ authorization: 'Bearer revoked.token' })
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException)
+    })
+
+    it('throws when jwt.verify throws (expired/tampered)', async () => {
+      vi.mocked(jwt.verify).mockImplementation(() => { throw new Error('invalid') })
+
+      const ctx = makeContext({ authorization: 'Bearer bad.token' })
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException)
+    })
+
+    it('throws when token type is not access', async () => {
+      vi.mocked(jwt.verify).mockReturnValue({
+        sub: 'user-1', workspaceId: 'ws-1', type: 'refresh', jti: 'jti-1',
+      } as never)
+
+      const ctx = makeContext({ authorization: 'Bearer refresh.token' })
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException)
+    })
+  })
+
+  describe('API key auth', () => {
+    it('allows request with valid x-api-key', async () => {
+      vi.mocked(proxy.validateApiKey).mockResolvedValue('ws-uuid-1')
+
+      const ctx = makeContext({ 'x-api-key': 'fm_abcdef' })
+      const result = await guard.canActivate(ctx)
+
+      expect(result).toBe(true)
+      const req = ctx.switchToHttp().getRequest() as any
+      expect(req.auth).toEqual({ workspaceId: 'ws-uuid-1' })
+    })
+
+    it('throws when api key is blacklisted', async () => {
+      vi.mocked(redis.isApiKeyBlacklisted).mockResolvedValue(true)
+
+      const ctx = makeContext({ 'x-api-key': 'fm_revoked' })
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException)
+    })
+
+    it('throws when proxy.validateApiKey returns null (key not found)', async () => {
+      vi.mocked(proxy.validateApiKey).mockResolvedValue(null)
+
+      const ctx = makeContext({ 'x-api-key': 'fm_unknown' })
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException)
+    })
+  })
+
+  it('throws when no credentials provided', async () => {
+    const ctx = makeContext({})
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException)
+  })
+})

--- a/apps/api-gateway/src/auth/auth.guard.ts
+++ b/apps/api-gateway/src/auth/auth.guard.ts
@@ -1,0 +1,98 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { JwtService } from '@nestjs/jwt'
+import { Request } from 'express'
+import * as crypto from 'crypto'
+import { RedisService } from '../redis/redis.service'
+import { ProxyService } from '../proxy/proxy.service'
+
+interface AccessTokenPayload {
+  sub: string
+  workspaceId: string
+  jti?: string
+  type: 'access'
+}
+
+export interface AuthContext {
+  userId?: string
+  workspaceId: string
+}
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  private readonly logger = new Logger(AuthGuard.name)
+
+  constructor(
+    private readonly jwt: JwtService,
+    private readonly config: ConfigService,
+    private readonly redis: RedisService,
+    private readonly proxy: ProxyService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>()
+    const authContext = await this.resolveAuthContext(request)
+    ;(request as Request & { auth: AuthContext }).auth = authContext
+    return true
+  }
+
+  private async resolveAuthContext(request: Request): Promise<AuthContext> {
+    const bearer = this.extractBearer(request)
+    if (bearer) {
+      return this.verifyJwt(bearer)
+    }
+
+    const apiKey = request.headers['x-api-key'] as string | undefined
+    if (apiKey) {
+      return this.verifyApiKey(apiKey)
+    }
+
+    throw new UnauthorizedException('missing authentication credentials')
+  }
+
+  private extractBearer(request: Request): string | undefined {
+    const auth = request.headers.authorization
+    if (!auth?.startsWith('Bearer ')) return undefined
+    return auth.slice(7)
+  }
+
+  private async verifyJwt(token: string): Promise<AuthContext> {
+    let payload: AccessTokenPayload
+    try {
+      payload = this.jwt.verify<AccessTokenPayload>(token, {
+        secret: this.config.get<string>('JWT_SECRET'),
+      })
+    } catch {
+      throw new UnauthorizedException('invalid access token')
+    }
+
+    if (payload.type !== 'access') {
+      throw new UnauthorizedException('invalid token type')
+    }
+
+    if (payload.jti) {
+      const blacklisted = await this.redis.isJtiBlacklisted(payload.jti)
+      if (blacklisted) throw new UnauthorizedException('token has been revoked')
+    }
+
+    return { userId: payload.sub, workspaceId: payload.workspaceId }
+  }
+
+  private async verifyApiKey(apiKey: string): Promise<AuthContext> {
+    const keyHash = crypto.createHash('sha256').update(apiKey).digest('hex')
+
+    const blacklisted = await this.redis.isApiKeyBlacklisted(keyHash)
+    if (blacklisted) throw new UnauthorizedException('api key has been revoked')
+
+    const workspaceId = await this.proxy.validateApiKey(keyHash)
+    if (!workspaceId) throw new UnauthorizedException('invalid api key')
+
+    return { workspaceId }
+  }
+}

--- a/apps/api-gateway/src/auth/auth.module.ts
+++ b/apps/api-gateway/src/auth/auth.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { JwtModule } from '@nestjs/jwt'
+import { RedisModule } from '../redis/redis.module'
+import { ProxyModule } from '../proxy/proxy.module'
+import { AuthGuard } from './auth.guard'
+
+@Module({
+  imports: [JwtModule.register({}), RedisModule, ProxyModule],
+  providers: [AuthGuard],
+  exports: [AuthGuard],
+})
+export class AuthModule {}

--- a/apps/api-gateway/src/config/config.module.ts
+++ b/apps/api-gateway/src/config/config.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import Joi from 'joi'
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      validationSchema: Joi.object({
+        NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
+        PORT: Joi.number().default(3000),
+        REDIS_EPHEMERAL_URL: Joi.string().required(),
+        REDIS_PERSISTENT_URL: Joi.string().required(),
+        JWT_SECRET: Joi.string().required(),
+        INGESTION_SERVICE_URL: Joi.string().required(),
+        CONFIG_SERVICE_URL: Joi.string().required(),
+        AUTH_SERVICE_URL: Joi.string().required(),
+        RATE_LIMIT_INGEST_RPM: Joi.number().default(1000),
+        RATE_LIMIT_MGMT_RPM: Joi.number().default(100),
+      }),
+      validationOptions: { abortEarly: false },
+    }),
+  ],
+})
+export class AppConfigModule {}

--- a/apps/api-gateway/src/ingest/ingest.controller.ts
+++ b/apps/api-gateway/src/ingest/ingest.controller.ts
@@ -1,0 +1,23 @@
+import { All, Controller, Req, Res, UseGuards } from '@nestjs/common'
+import { Request, Response } from 'express'
+import { ConfigService } from '@nestjs/config'
+import { AuthGuard } from '../auth/auth.guard'
+import { RateLimitGuard, RateLimit } from '../rate-limit/rate-limit.guard'
+import { ProxyService } from '../proxy/proxy.service'
+
+@Controller('ingest')
+@UseGuards(AuthGuard, RateLimitGuard)
+@RateLimit('ingest')
+export class IngestController {
+  constructor(
+    private readonly proxy: ProxyService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @All('*')
+  async forward(@Req() req: Request, @Res() res: Response): Promise<void> {
+    const base = this.config.get<string>('INGESTION_SERVICE_URL')!
+    const path = req.path.replace(/^\/ingest/, '') || '/'
+    await this.proxy.forward(req, res, `${base}${path}`)
+  }
+}

--- a/apps/api-gateway/src/ingest/ingest.module.ts
+++ b/apps/api-gateway/src/ingest/ingest.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { IngestController } from './ingest.controller'
+import { AuthModule } from '../auth/auth.module'
+import { RateLimitModule } from '../rate-limit/rate-limit.module'
+import { ProxyModule } from '../proxy/proxy.module'
+
+@Module({
+  imports: [AuthModule, RateLimitModule, ProxyModule],
+  controllers: [IngestController],
+})
+export class IngestModule {}

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -1,0 +1,39 @@
+import { NestFactory } from '@nestjs/core'
+import { ValidationPipe } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Logger } from 'nestjs-pino'
+import { AppModule } from './app.module'
+import { HttpExceptionFilter } from '@flowmesh/nestjs-common'
+
+const DRAIN_DELAY_MS = 5000
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, { bufferLogs: true })
+  const config = app.get(ConfigService)
+
+  app.useLogger(app.get(Logger))
+  app.useGlobalFilters(app.get(HttpExceptionFilter))
+  app.useGlobalPipes(new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+  }))
+
+  const logger = app.get(Logger)
+
+  process.on('SIGTERM', async () => {
+    logger.log('SIGTERM received — draining connections', 'ApiGateway')
+    await new Promise((resolve) => setTimeout(resolve, DRAIN_DELAY_MS))
+    await app.close()
+  })
+
+  process.on('SIGINT', async () => {
+    await app.close()
+  })
+
+  const port = config.get<number>('PORT')!
+  await app.listen(port, '0.0.0.0')
+  logger.log(`API Gateway listening on port ${port}`, 'ApiGateway')
+}
+
+bootstrap()

--- a/apps/api-gateway/src/management/management.controller.ts
+++ b/apps/api-gateway/src/management/management.controller.ts
@@ -1,0 +1,37 @@
+import { All, Controller, Req, Res, UseGuards } from '@nestjs/common'
+import { Request, Response } from 'express'
+import { ConfigService } from '@nestjs/config'
+import { AuthGuard } from '../auth/auth.guard'
+import { RateLimitGuard, RateLimit } from '../rate-limit/rate-limit.guard'
+import { ProxyService } from '../proxy/proxy.service'
+
+// Routes all authenticated management API calls to the appropriate downstream service.
+// /pipelines/* and /destinations/* → config-service
+// /api-keys/* → auth service
+@Controller()
+@UseGuards(AuthGuard, RateLimitGuard)
+@RateLimit('mgmt')
+export class ManagementController {
+  constructor(
+    private readonly proxy: ProxyService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @All('pipelines*')
+  async pipelines(@Req() req: Request, @Res() res: Response): Promise<void> {
+    const base = this.config.get<string>('CONFIG_SERVICE_URL')!
+    await this.proxy.forward(req, res, `${base}${req.path}`)
+  }
+
+  @All('destinations*')
+  async destinations(@Req() req: Request, @Res() res: Response): Promise<void> {
+    const base = this.config.get<string>('CONFIG_SERVICE_URL')!
+    await this.proxy.forward(req, res, `${base}${req.path}`)
+  }
+
+  @All('api-keys*')
+  async apiKeys(@Req() req: Request, @Res() res: Response): Promise<void> {
+    const base = this.config.get<string>('AUTH_SERVICE_URL')!
+    await this.proxy.forward(req, res, `${base}${req.path}`)
+  }
+}

--- a/apps/api-gateway/src/management/management.module.ts
+++ b/apps/api-gateway/src/management/management.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { ManagementController } from './management.controller'
+import { PublicAuthController } from './public-auth.controller'
+import { AuthModule } from '../auth/auth.module'
+import { RateLimitModule } from '../rate-limit/rate-limit.module'
+import { ProxyModule } from '../proxy/proxy.module'
+
+@Module({
+  imports: [AuthModule, RateLimitModule, ProxyModule],
+  controllers: [ManagementController, PublicAuthController],
+})
+export class ManagementModule {}

--- a/apps/api-gateway/src/management/public-auth.controller.ts
+++ b/apps/api-gateway/src/management/public-auth.controller.ts
@@ -1,0 +1,19 @@
+import { All, Controller, Req, Res } from '@nestjs/common'
+import { Request, Response } from 'express'
+import { ConfigService } from '@nestjs/config'
+import { ProxyService } from '../proxy/proxy.service'
+
+// Public auth endpoints — no authentication required (users don't have tokens yet)
+@Controller('auth')
+export class PublicAuthController {
+  constructor(
+    private readonly proxy: ProxyService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @All('*')
+  async forward(@Req() req: Request, @Res() res: Response): Promise<void> {
+    const base = this.config.get<string>('AUTH_SERVICE_URL')!
+    await this.proxy.forward(req, res, `${base}${req.path}`)
+  }
+}

--- a/apps/api-gateway/src/proxy/proxy.module.ts
+++ b/apps/api-gateway/src/proxy/proxy.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { HttpModule } from '@nestjs/axios'
+import { ProxyService } from './proxy.service'
+
+@Module({
+  imports: [HttpModule],
+  providers: [ProxyService],
+  exports: [ProxyService],
+})
+export class ProxyModule {}

--- a/apps/api-gateway/src/proxy/proxy.service.spec.ts
+++ b/apps/api-gateway/src/proxy/proxy.service.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ServiceUnavailableException } from '@nestjs/common'
+import { HttpService } from '@nestjs/axios'
+import { ConfigService } from '@nestjs/config'
+import { of, throwError } from 'rxjs'
+import { AxiosResponse } from 'axios'
+import { ProxyService } from './proxy.service'
+
+const makeHttp = () => ({
+  request: vi.fn(),
+  post: vi.fn(),
+}) as unknown as HttpService
+
+const makeConfig = () => ({
+  get: vi.fn((key: string) => {
+    const map: Record<string, string> = {
+      AUTH_SERVICE_URL: 'http://auth:3004',
+      INGESTION_SERVICE_URL: 'http://ingestion:3001',
+    }
+    return map[key]
+  }),
+}) as unknown as ConfigService
+
+const makeAxiosResponse = (data: unknown, status = 200): AxiosResponse => ({
+  data,
+  status,
+  headers: { 'content-type': 'application/json' },
+  statusText: 'OK',
+  config: {} as never,
+})
+
+describe('ProxyService', () => {
+  let http: ReturnType<typeof makeHttp>
+  let config: ReturnType<typeof makeConfig>
+  let service: ProxyService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    http = makeHttp()
+    config = makeConfig()
+    service = new ProxyService(http, config)
+  })
+
+  describe('forward', () => {
+    it('forwards request and sets status + body from upstream', async () => {
+      vi.mocked(http.request).mockReturnValue(of(makeAxiosResponse({ ok: true }, 202)))
+      const req = {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-correlation-id': 'corr-1' },
+        body: { event: 'test' },
+        auth: { workspaceId: 'ws-1', userId: 'user-1' },
+      } as never
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn(), setHeader: vi.fn() }
+
+      await service.forward(req, res as never, 'http://ingestion:3001/events')
+
+      expect(res.status).toHaveBeenCalledWith(202)
+      expect(res.json).toHaveBeenCalledWith({ ok: true })
+    })
+
+    it('throws ServiceUnavailableException when upstream is down', async () => {
+      vi.mocked(http.request).mockReturnValue(throwError(() => new Error('ECONNREFUSED')))
+      const req = {
+        method: 'GET',
+        headers: {},
+        body: undefined,
+        auth: { workspaceId: 'ws-1' },
+      } as never
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn(), setHeader: vi.fn() }
+
+      await expect(service.forward(req, res as never, 'http://ingestion:3001/')).rejects.toThrow(
+        ServiceUnavailableException,
+      )
+    })
+  })
+
+  describe('validateApiKey', () => {
+    it('returns workspaceId when auth service confirms key', async () => {
+      vi.mocked(http.post).mockReturnValue(of(makeAxiosResponse({ workspaceId: 'ws-1' })))
+      const result = await service.validateApiKey('hashvalue')
+      expect(result).toBe('ws-1')
+    })
+
+    it('returns null when auth service is unreachable', async () => {
+      vi.mocked(http.post).mockReturnValue(throwError(() => new Error('ECONNREFUSED')))
+      const result = await service.validateApiKey('hashvalue')
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/apps/api-gateway/src/proxy/proxy.service.ts
+++ b/apps/api-gateway/src/proxy/proxy.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { HttpService } from '@nestjs/axios'
+import { Request, Response } from 'express'
+import { firstValueFrom, catchError } from 'rxjs'
+import { AxiosError, AxiosRequestConfig } from 'axios'
+import { AuthContext } from '../auth/auth.guard'
+import { CORRELATION_ID_HEADER } from '@flowmesh/nestjs-common'
+
+const PROXY_TIMEOUT_MS = 10_000
+
+@Injectable()
+export class ProxyService {
+  private readonly logger = new Logger(ProxyService.name)
+
+  constructor(
+    private readonly http: HttpService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async forward(
+    request: Request & { auth?: AuthContext },
+    response: Response,
+    targetUrl: string,
+  ): Promise<void> {
+    const headers = this.buildForwardHeaders(request)
+    const config: AxiosRequestConfig = {
+      method: request.method as AxiosRequestConfig['method'],
+      url: targetUrl,
+      headers,
+      data: request.body,
+      timeout: PROXY_TIMEOUT_MS,
+      validateStatus: () => true,
+    }
+
+    const { data, status, headers: resHeaders } = await firstValueFrom(
+      this.http.request(config).pipe(
+        catchError((err: AxiosError) => {
+          this.logger.error({ url: targetUrl, err: err.message }, 'proxy request failed')
+          throw new ServiceUnavailableException('upstream service unavailable')
+        }),
+      ),
+    )
+
+    const forwardedHeaders = ['content-type', 'x-correlation-id']
+    for (const header of forwardedHeaders) {
+      if (resHeaders[header]) response.setHeader(header, resHeaders[header] as string)
+    }
+
+    response.status(status).json(data)
+  }
+
+  async validateApiKey(keyHash: string): Promise<string | null> {
+    const url = `${this.config.get('AUTH_SERVICE_URL')}/internal/api-keys/validate`
+    try {
+      const { data } = await firstValueFrom(
+        this.http.post<{ workspaceId: string }>(url, { keyHash }, { timeout: PROXY_TIMEOUT_MS }).pipe(
+          catchError(() => { throw new Error('auth service unavailable') }),
+        ),
+      )
+      return data.workspaceId
+    } catch {
+      return null
+    }
+  }
+
+  private buildForwardHeaders(request: Request & { auth?: AuthContext }): Record<string, string> {
+    const headers: Record<string, string> = {
+      'content-type': request.headers['content-type'] ?? 'application/json',
+    }
+
+    const correlationId = request.headers[CORRELATION_ID_HEADER] as string | undefined
+    if (correlationId) headers[CORRELATION_ID_HEADER] = correlationId
+
+    if (request.auth?.workspaceId) headers['x-workspace-id'] = request.auth.workspaceId
+    if (request.auth?.userId) headers['x-user-id'] = request.auth.userId
+
+    return headers
+  }
+}

--- a/apps/api-gateway/src/rate-limit/rate-limit.guard.spec.ts
+++ b/apps/api-gateway/src/rate-limit/rate-limit.guard.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Reflector } from '@nestjs/core'
+import { RateLimitGuard, RATE_LIMIT_TIER } from './rate-limit.guard'
+import { RedisService } from '../redis/redis.service'
+
+const makeRedis = () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(true),
+}) as unknown as RedisService
+
+const makeConfig = () => ({
+  get: vi.fn((key: string) => key === 'RATE_LIMIT_INGEST_RPM' ? 1000 : 100),
+}) as unknown as ConfigService
+
+const makeReflector = (tier: string) => ({
+  get: vi.fn().mockReturnValue(tier),
+}) as unknown as Reflector
+
+const makeContext = (auth: { workspaceId?: string } = { workspaceId: 'ws-1' }): ExecutionContext => {
+  const headers: Record<string, string> = {}
+  const response = { setHeader: vi.fn() }
+  return {
+    getHandler: () => ({}),
+    switchToHttp: () => ({
+      getRequest: () => ({ auth, ip: '127.0.0.1', headers }),
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext
+}
+
+describe('RateLimitGuard', () => {
+  let redis: ReturnType<typeof makeRedis>
+  let config: ReturnType<typeof makeConfig>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    redis = makeRedis()
+    config = makeConfig()
+  })
+
+  it('allows request under ingest limit', async () => {
+    const guard = new RateLimitGuard(redis, config, makeReflector('ingest'))
+    vi.mocked(redis.checkRateLimit).mockResolvedValue(true)
+    expect(await guard.canActivate(makeContext())).toBe(true)
+    expect(redis.checkRateLimit).toHaveBeenCalledWith('ingest:ws-1', 1000)
+  })
+
+  it('allows request under mgmt limit', async () => {
+    const guard = new RateLimitGuard(redis, config, makeReflector('mgmt'))
+    vi.mocked(redis.checkRateLimit).mockResolvedValue(true)
+    expect(await guard.canActivate(makeContext())).toBe(true)
+    expect(redis.checkRateLimit).toHaveBeenCalledWith('mgmt:ws-1', 100)
+  })
+
+  it('throws TooManyRequestsException when limit exceeded', async () => {
+    const guard = new RateLimitGuard(redis, config, makeReflector('ingest'))
+    vi.mocked(redis.checkRateLimit).mockResolvedValue(false)
+    const err = await guard.canActivate(makeContext()).catch(e => e)
+    expect(err).toBeInstanceOf(HttpException)
+    expect(err.getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS)
+  })
+
+  it('uses ip as identifier when no auth context', async () => {
+    const guard = new RateLimitGuard(redis, config, makeReflector('mgmt'))
+    await guard.canActivate(makeContext({}))
+    expect(redis.checkRateLimit).toHaveBeenCalledWith('mgmt:127.0.0.1', 100)
+  })
+
+  it('sets Retry-After header when limit exceeded', async () => {
+    const guard = new RateLimitGuard(redis, config, makeReflector('mgmt'))
+    vi.mocked(redis.checkRateLimit).mockResolvedValue(false)
+    const ctx = makeContext()
+    const res = ctx.switchToHttp().getResponse() as { setHeader: ReturnType<typeof vi.fn> }
+    await expect(guard.canActivate(ctx)).rejects.toThrow()
+    expect(res.setHeader).toHaveBeenCalledWith('Retry-After', '60')
+  })
+})

--- a/apps/api-gateway/src/rate-limit/rate-limit.guard.ts
+++ b/apps/api-gateway/src/rate-limit/rate-limit.guard.ts
@@ -1,0 +1,53 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+  SetMetadata,
+} from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Reflector } from '@nestjs/core'
+import { Request, Response } from 'express'
+import { RedisService } from '../redis/redis.service'
+import { AuthContext } from '../auth/auth.guard'
+
+export type RateLimitTier = 'ingest' | 'mgmt'
+export const RATE_LIMIT_TIER = 'rateLimitTier'
+export const RateLimit = (tier: RateLimitTier) => SetMetadata(RATE_LIMIT_TIER, tier)
+
+@Injectable()
+export class RateLimitGuard implements CanActivate {
+  private readonly logger = new Logger(RateLimitGuard.name)
+
+  constructor(
+    private readonly redis: RedisService,
+    private readonly config: ConfigService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const tier = this.reflector.get<RateLimitTier>(RATE_LIMIT_TIER, context.getHandler()) ?? 'mgmt'
+    const request = context.switchToHttp().getRequest<Request & { auth: AuthContext }>()
+    const response = context.switchToHttp().getResponse<Response>()
+
+    const limit = tier === 'ingest'
+      ? this.config.get<number>('RATE_LIMIT_INGEST_RPM')!
+      : this.config.get<number>('RATE_LIMIT_MGMT_RPM')!
+
+    const identifier = `${tier}:${request.auth?.workspaceId ?? request.ip}`
+    const allowed = await this.redis.checkRateLimit(identifier, limit)
+
+    response.setHeader('X-RateLimit-Limit', limit)
+    response.setHeader('X-RateLimit-Tier', tier)
+
+    if (!allowed) {
+      response.setHeader('Retry-After', '60')
+      this.logger.warn({ identifier, tier }, 'rate limit exceeded')
+      throw new HttpException('rate limit exceeded', HttpStatus.TOO_MANY_REQUESTS)
+    }
+
+    return true
+  }
+}

--- a/apps/api-gateway/src/rate-limit/rate-limit.module.ts
+++ b/apps/api-gateway/src/rate-limit/rate-limit.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { RedisModule } from '../redis/redis.module'
+import { RateLimitGuard } from './rate-limit.guard'
+
+@Module({
+  imports: [RedisModule],
+  providers: [RateLimitGuard],
+  exports: [RateLimitGuard],
+})
+export class RateLimitModule {}

--- a/apps/api-gateway/src/redis/redis.module.ts
+++ b/apps/api-gateway/src/redis/redis.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { RedisService } from './redis.service'
+
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/apps/api-gateway/src/redis/redis.service.ts
+++ b/apps/api-gateway/src/redis/redis.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import Redis from 'ioredis'
+
+const BLACKLIST_PREFIX = 'auth:blacklist'
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(RedisService.name)
+  private ephemeral!: Redis
+  private persistent!: Redis
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    this.ephemeral = new Redis(this.config.get<string>('REDIS_EPHEMERAL_URL')!)
+    this.persistent = new Redis(this.config.get<string>('REDIS_PERSISTENT_URL')!)
+    this.ephemeral.on('error', (err: Error) => this.logger.error(`Redis ephemeral error: ${err.message}`))
+    this.persistent.on('error', (err: Error) => this.logger.error(`Redis persistent error: ${err.message}`))
+  }
+
+  async onModuleDestroy() {
+    await Promise.all([this.ephemeral.quit(), this.persistent.quit()])
+  }
+
+  async isJtiBlacklisted(jti: string): Promise<boolean> {
+    return (await this.persistent.exists(`${BLACKLIST_PREFIX}:${jti}`)) === 1
+  }
+
+  async isApiKeyBlacklisted(keyHash: string): Promise<boolean> {
+    return (await this.persistent.exists(`${BLACKLIST_PREFIX}:apikey:${keyHash}`)) === 1
+  }
+
+  // Fixed-window rate limit. Returns true if the request is allowed.
+  async checkRateLimit(identifier: string, limitPerMinute: number): Promise<boolean> {
+    const window = Math.floor(Date.now() / 60_000)
+    const key = `gateway:ratelimit:${identifier}:${window}`
+    const count = await this.ephemeral.incr(key)
+    if (count === 1) {
+      await this.ephemeral.expire(key, 120)
+    }
+    return count <= limitPerMinute
+  }
+}

--- a/apps/api-gateway/tsconfig.json
+++ b/apps/api-gateway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/auth/src/api-key/api-key.module.ts
+++ b/apps/auth/src/api-key/api-key.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common'
 import { ApiKeyService } from './api-key.service'
 import { ApiKeyController } from './api-key.controller'
+import { InternalApiKeyController } from './internal-api-key.controller'
 import { AuthModule } from '../auth/auth.module'
 
 @Module({
   imports: [AuthModule],
   providers: [ApiKeyService],
-  controllers: [ApiKeyController],
+  controllers: [ApiKeyController, InternalApiKeyController],
 })
 export class ApiKeyModule {}

--- a/apps/auth/src/api-key/api-key.service.ts
+++ b/apps/auth/src/api-key/api-key.service.ts
@@ -68,8 +68,10 @@ export class ApiKeyService {
   }
 
   async validateApiKey(rawKey: string): Promise<{ workspaceId: string } | null> {
-    const keyHash = this.hashKey(rawKey)
+    return this.validateByHash(this.hashKey(rawKey))
+  }
 
+  async validateByHash(keyHash: string): Promise<{ workspaceId: string } | null> {
     const blacklisted = await this.redis.isApiKeyBlacklisted(keyHash)
     if (blacklisted) return null
 

--- a/apps/auth/src/api-key/internal-api-key.controller.spec.ts
+++ b/apps/auth/src/api-key/internal-api-key.controller.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { UnauthorizedException } from '@nestjs/common'
+import { InternalApiKeyController } from './internal-api-key.controller'
+import { ApiKeyService } from './api-key.service'
+
+const makeApiKeyService = () => ({
+  validateByHash: vi.fn(),
+}) as unknown as ApiKeyService
+
+describe('InternalApiKeyController', () => {
+  let service: ReturnType<typeof makeApiKeyService>
+  let controller: InternalApiKeyController
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = makeApiKeyService()
+    controller = new InternalApiKeyController(service)
+  })
+
+  it('returns workspaceId for a valid key hash', async () => {
+    vi.mocked(service.validateByHash).mockResolvedValue({ workspaceId: 'ws-uuid-1' })
+    const result = await controller.validate({ keyHash: 'abc123' })
+    expect(result).toEqual({ workspaceId: 'ws-uuid-1' })
+  })
+
+  it('throws UnauthorizedException when key hash not found', async () => {
+    vi.mocked(service.validateByHash).mockResolvedValue(null)
+    await expect(controller.validate({ keyHash: 'unknown' })).rejects.toThrow(UnauthorizedException)
+  })
+})

--- a/apps/auth/src/api-key/internal-api-key.controller.ts
+++ b/apps/auth/src/api-key/internal-api-key.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, UnauthorizedException } from '@nestjs/common'
+import { IsString, IsNotEmpty } from 'class-validator'
+import { ApiKeyService } from './api-key.service'
+
+class ValidateByHashDto {
+  @IsString()
+  @IsNotEmpty()
+  keyHash!: string
+}
+
+// Internal endpoint — only reachable from within the Docker network (not exposed publicly)
+@Controller('internal/api-keys')
+export class InternalApiKeyController {
+  constructor(private readonly apiKeyService: ApiKeyService) {}
+
+  @Post('validate')
+  @HttpCode(HttpStatus.OK)
+  async validate(@Body() dto: ValidateByHashDto): Promise<{ workspaceId: string }> {
+    const result = await this.apiKeyService.validateByHash(dto.keyHash)
+    if (!result) throw new UnauthorizedException('invalid api key')
+    return result
+  }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       AUTH_SERVICE_URL: http://auth:3004
       REDIS_EPHEMERAL_URL: redis://redis-ephemeral:6379
       REDIS_PERSISTENT_URL: redis://redis-persistent:6379
+      JWT_SECRET: ${JWT_SECRET}
     depends_on:
       redis-ephemeral:
         condition: service_healthy

--- a/docs/adr/ADR-013-edge-reverse-proxy-traefik.md
+++ b/docs/adr/ADR-013-edge-reverse-proxy-traefik.md
@@ -1,0 +1,86 @@
+# ADR-013: Traefik as Edge Reverse Proxy over Nginx/OpenResty
+
+**Date:** 2026-05-02
+**Status:** Accepted
+**Deciders:** Arif Iqbal
+
+## Context
+
+FlowMesh needs an edge reverse proxy that sits in front of the API Gateway to handle:
+
+- TLS termination (HTTPS on port 443, HTTP redirect on port 80)
+- Automatic SSL certificate provisioning and renewal
+- WebSocket proxying with sticky sessions (required by the Phase 2 live dashboard)
+- Load balancing across API Gateway replicas when horizontally scaled
+
+The proxy must work with FlowMesh's Docker Compose self-hosted deployment model. The target user runs `docker-compose up` on a single VPS and expects a production-ready HTTPS endpoint without manual certificate management.
+
+The two main candidates evaluated were Traefik and Nginx (including OpenResty, the Lua-extended variant).
+
+## Decision
+
+Use **Traefik v3** as the edge reverse proxy for FlowMesh's Docker Compose deployment.
+
+## Architecture
+
+```
+Internet :443 / :80
+       ↓
+    Traefik          ← TLS termination, WebSocket sticky sessions, load balancing
+       ↓
+  API Gateway :3000  ← auth, rate limiting, routing (internal network only)
+       ↓
+  Ingestion / Config / Auth / Pipeline / Delivery (internal network only)
+```
+
+No downstream service is exposed on a public port. Only Traefik binds to 80 and 443 on the host.
+
+## Consequences
+
+### Positive
+- **Zero-config SSL** — Traefik integrates with Let's Encrypt via `certificatesresolvers`. A single label on the API Gateway container (`traefik.http.routers.gateway.tls.certresolver=letsencrypt`) provisions and auto-renews the certificate with no certbot cron job or manual renewal
+- **Docker-native configuration** — routing rules live as Docker labels on each service container. No separate Traefik config file needs to be updated when a service is added or its port changes
+- **WebSocket support** — Traefik proxies WebSocket connections transparently and supports sticky sessions via cookie-based load balancing, which is required for the Phase 2 dashboard's Redis pub/sub WebSocket feed
+- **Dynamic reconfiguration** — Traefik watches the Docker socket and reconfigures itself when containers start or stop, without a reload or restart
+- **Dashboard and metrics** — Traefik's built-in dashboard gives operators visibility into routes, middleware, and upstream health without extra tooling
+- **Middleware composability** — Traefik's middleware chain (IP allowlist, headers, redirect) is declared in labels, keeping routing logic co-located with the service definition
+
+### Negative
+- **Docker socket exposure** — Traefik reads the Docker socket to discover containers. The socket must be mounted read-only (`/var/run/docker.sock:/var/run/docker.sock:ro`) and Traefik should run with a restricted user. Mounting the socket always carries a privilege escalation risk if the container is compromised
+- **Less flexibility at the edge** — Nginx/OpenResty supports Lua scripting for custom logic (advanced rate limiting, request signing, geo-blocking) directly at the proxy layer. Traefik's middleware is more opinionated and does not support arbitrary scripting. For FlowMesh's use case this is not needed — all custom logic lives in the API Gateway
+- **Learning curve for complex routing** — Traefik's label-based DSL is more verbose than Nginx's declarative config for advanced routing scenarios (e.g., path rewriting, complex header manipulation). For FlowMesh's simple "proxy all traffic to API Gateway" topology this is not a problem
+
+### Neutral
+- Both Traefik and Nginx support HTTP/2 and gzip compression
+- Both are production-battle-tested at scale
+- Traefik is written in Go; Nginx is written in C — neither has meaningful performance differences for FlowMesh's traffic profile
+
+## Alternatives Considered
+
+### Nginx (standard)
+Nginx is the most widely deployed reverse proxy. It is extremely stable, has excellent documentation, and its config syntax is well understood. However, SSL certificate management requires a separate certbot container and a cron job for renewal. Adding a new service requires editing `nginx.conf` and sending a `SIGHUP` reload signal. For the FlowMesh self-hosted use case, this is unnecessary operational burden — the user should not need to know Nginx configuration to run FlowMesh.
+
+### OpenResty (Nginx + LuaJIT)
+OpenResty adds Lua scripting to Nginx, enabling custom logic at the proxy layer. This is valuable for high-performance edge use cases (Cloudflare, Kong API Gateway) where request processing must happen at the proxy without a hop to an application server. FlowMesh already has an API Gateway service that handles auth, rate limiting, and routing. Duplicating or splitting this logic at the Nginx layer would create two places to maintain the same rules and introduce subtle inconsistencies. OpenResty's power is not needed here.
+
+### Caddy
+Caddy has automatic HTTPS similar to Traefik and a clean JSON/Caddyfile config format. It is a valid alternative. Traefik is preferred because its Docker provider is more mature and widely used in the self-hosted open-source community, and its label-based configuration aligns better with the Docker Compose deployment model FlowMesh targets.
+
+### No edge proxy (API Gateway on port 443 directly)
+Terminating TLS inside the NestJS API Gateway using `@nestjs/core` and Node's `https` module is possible but inadvisable. Node is not optimised for TLS termination at scale, certificate renewal becomes an application concern, and the Gateway process would need to run as root or use `setcap` to bind to port 443. Keeping TLS at the infrastructure layer is the correct separation of concerns.
+
+## Implementation Notes
+
+Traefik will be added to `docker/docker-compose.yml` during Phase 5 (deployment polish) alongside Dockerfiles for each service. The API Gateway container will gain the following labels:
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.gateway.rule=Host(`your-domain.com`)"
+  - "traefik.http.routers.gateway.entrypoints=websecure"
+  - "traefik.http.routers.gateway.tls.certresolver=letsencrypt"
+  - "traefik.http.services.gateway.loadbalancer.server.port=3000"
+  - "traefik.http.services.gateway.loadbalancer.sticky.cookie=true"
+```
+
+The `sticky.cookie=true` setting ensures WebSocket connections in the Phase 2 dashboard are routed to the same Gateway replica for the lifetime of the connection.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,79 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.39)
 
+  apps/api-gateway:
+    dependencies:
+      '@flowmesh/nestjs-common':
+        specifier: workspace:*
+        version: link:../../packages/nestjs-common
+      '@nestjs/axios':
+        specifier: ^3.0.2
+        version: 3.1.3(@nestjs/common@10.4.22)(axios@1.15.2)(rxjs@7.8.2)
+      '@nestjs/common':
+        specifier: ^10.3.0
+        version: 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config':
+        specifier: ^4.0.4
+        version: 4.0.4(@nestjs/common@10.4.22)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22)(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/jwt':
+        specifier: ^10.2.0
+        version: 10.2.0(@nestjs/common@10.4.22)
+      '@nestjs/platform-express':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)
+      axios:
+        specifier: ^1.6.0
+        version: 1.15.2
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.14.1
+        version: 0.14.4
+      ioredis:
+        specifier: ^5.3.2
+        version: 5.10.1
+      joi:
+        specifier: ^18.1.2
+        version: 18.1.2
+      nestjs-pino:
+        specifier: ^3.5.0
+        version: 3.5.0(@nestjs/common@10.4.22)(pino-http@8.6.1)
+      pino:
+        specifier: '8'
+        version: 8.21.0
+      pino-http:
+        specifier: ^8.6.1
+        version: 8.6.1
+      reflect-metadata:
+        specifier: 0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+    devDependencies:
+      '@nestjs/cli':
+        specifier: ^10.3.0
+        version: 10.4.9(@swc/core@1.15.30)
+      '@nestjs/testing':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.39
+      pino-pretty:
+        specifier: ^10.3.1
+        version: 10.3.1
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   apps/auth:
     dependencies:
       '@flowmesh/nestjs-common':
@@ -1024,6 +1097,18 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: false
+
+  /@nestjs/axios@3.1.3(@nestjs/common@10.4.22)(axios@1.15.2)(rxjs@7.8.2):
+    resolution: {integrity: sha512-RZ/63c1tMxGLqyG3iOCVt7A72oy4x1eM6QEhd4KzCYpaVWW0igq0WSREeRoEZhIxRcZfDfIIkvsOMiM7yfVGZQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+      axios: ^1.3.1
+      rxjs: ^6.0.0 || ^7.0.0
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      axios: 1.15.2
+      rxjs: 7.8.2
     dev: false
 
   /@nestjs/cli@10.4.9(@swc/core@1.15.30):
@@ -2263,11 +2348,20 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  /axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2578,7 +2672,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2797,7 +2890,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -2948,7 +3040,6 @@ packages:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.3
-    dev: true
 
   /esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -3164,6 +3255,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -3204,7 +3305,6 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.3
       mime-types: 2.1.35
-    dev: true
 
   /formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
@@ -3386,7 +3486,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.1.0
-    dev: true
 
   /has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
@@ -4359,6 +4458,11 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  /proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+    dev: false
 
   /pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}


### PR DESCRIPTION
## Summary

- **Auth guard** — verifies JWT access tokens (signature + Redis 2 JTI blacklist check) and API keys (Redis 2 blacklist fast-path + internal call to auth service to get workspaceId)
- **Rate limiting** — fixed-window per workspace: 1,000 rpm on `/ingest/*`, 100 rpm on management routes; `Retry-After` header on 429
- **Proxy service** — forwards authenticated requests to ingestion, config-service, or auth; injects `x-workspace-id` and `x-user-id` headers for downstream services
- **Route layout** — public `/auth/*` (no guard), authenticated `/ingest/*`, `/pipelines/*`, `/destinations/*`, `/api-keys/*`
- **Auth service addition** — `POST /internal/api-keys/validate` endpoint (network-internal only) used by the gateway for API key workspace resolution

## Test plan

- [ ] `make gateway-dev` starts on port 3000
- [ ] `POST /auth/register` creates a user and returns token pair
- [ ] `POST /auth/login` returns token pair
- [ ] `POST /ingest/events` with valid Bearer token returns 202 from ingestion service
- [ ] `POST /ingest/events` with valid `x-api-key` returns 202
- [ ] `POST /ingest/events` with no credentials returns 401
- [ ] `POST /ingest/events` with revoked token returns 401
- [ ] Exceeding 1000 rpm on `/ingest/*` returns 429 with `Retry-After` header
- [ ] `GET /pipelines` with valid auth proxies to config-service
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)