### PR TITLE
fix(gateway): IPv6 localhost fix and auth module DI fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,19 @@
 # ─── Database ────────────────────────────────────────────────────────────────
 # Local dev: Postgres is exposed on port 5433 by Docker
 # Production: use PgBouncer URL (port 5432 inside Docker network)
-DATABASE_URL="postgresql://flowmesh:change_me@localhost:5433/flowmesh?schema=<service-name>"
+DATABASE_URL="postgresql://flowmesh:change_me@127.0.0.1:5433/flowmesh?schema=<service-name>"
 POSTGRES_PASSWORD="change_me"
 
 # ─── RabbitMQ ────────────────────────────────────────────────────────────────
-RABBITMQ_URL="amqp://flowmesh:change_me@localhost:5672/flowmesh"
+RABBITMQ_URL="amqp://flowmesh:change_me@127.0.0.1:5672/flowmesh"
 RABBITMQ_PASSWORD="change_me"
 
 # ─── Redis ───────────────────────────────────────────────────────────────────
 # Redis 1 — ephemeral (rate limits, pipeline cache, pub/sub). No persistence.
 # Not required by ingestion; used by config-service and planned pipeline/api-gateway services.
-REDIS_EPHEMERAL_URL="redis://localhost:6379"
+REDIS_EPHEMERAL_URL="redis://127.0.0.1:6379"
 # Redis 2 — persistent AOF (idempotency keys, token blacklist, quotas)
-REDIS_PERSISTENT_URL="redis://localhost:6380"
+REDIS_PERSISTENT_URL="redis://127.0.0.1:6380"
 
 # ─── Auth ────────────────────────────────────────────────────────────────────
 # Generate secrets with: make gen-jwt-secret
@@ -29,7 +29,7 @@ CONFIG_ENCRYPTION_KEY="change_me_must_be_64_hex_chars_exactly_000000000000000000
 
 # ─── Pipeline service ────────────────────────────────────────────────────────
 # URL of config-service for pipeline to fetch pipeline definitions
-CONFIG_SERVICE_URL="http://localhost:3005"
+CONFIG_SERVICE_URL="http://127.0.0.1:3005"
 
 # ─── Service ports ───────────────────────────────────────────────────────────
 # api-gateway: 3000  ingestion: 3001  pipeline: 3002  delivery: 3003

--- a/apps/api-gateway/src/auth/auth.module.ts
+++ b/apps/api-gateway/src/auth/auth.module.ts
@@ -7,6 +7,6 @@ import { AuthGuard } from './auth.guard'
 @Module({
   imports: [JwtModule.register({}), RedisModule, ProxyModule],
   providers: [AuthGuard],
-  exports: [AuthGuard],
+  exports: [AuthGuard, JwtModule, RedisModule],
 })
 export class AuthModule {}

--- a/smoke-test-gateway.sh
+++ b/smoke-test-gateway.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Gateway smoke test — runs against a locally running API Gateway on port 3000.
+# Prerequisites: make infra-up && make auth-dev && make gateway-dev
+
+set -euo pipefail
+
+GATEWAY="http://localhost:3000"
+AUTH="http://localhost:3004"
+PASS=0
+FAIL=0
+
+green() { printf "\033[32m✓\033[0m %s\n" "$1"; }
+red()   { printf "\033[31m✗\033[0m %s\n" "$1"; }
+
+check() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  if echo "$actual" | grep -q "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected: $expected, got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "=== FlowMesh Gateway Smoke Test ==="
+echo "Gateway: $GATEWAY"
+echo ""
+
+# ── Health ────────────────────────────────────────────────────────────────────
+
+echo "--- Health ---"
+HEALTH=$(curl -s "$GATEWAY/health")
+check "GET /health returns ok" '"status":"ok"' "$HEALTH"
+
+# ── Public auth routes (no credentials required) ─────────────────────────────
+
+echo ""
+echo "--- Public auth routes ---"
+
+REGISTER=$(curl -s -X POST "$GATEWAY/auth/register" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"smoke@flowmesh.dev","password":"Password123!","workspaceName":"smoke-workspace"}' \
+  -w "\n%{http_code}")
+HTTP_CODE=$(echo "$REGISTER" | tail -1)
+BODY=$(echo "$REGISTER" | head -1)
+check "POST /auth/register returns 201 or 409 (already exists)" "201\|409" "$HTTP_CODE"
+
+LOGIN=$(curl -s -X POST "$GATEWAY/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"smoke@flowmesh.dev","password":"Password123!"}')
+check "POST /auth/login returns accessToken" "accessToken" "$LOGIN"
+
+ACCESS_TOKEN=$(echo "$LOGIN" | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
+
+# ── Protected routes — no credentials → 401 ──────────────────────────────────
+
+echo ""
+echo "--- Auth enforcement ---"
+
+NO_AUTH=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY/pipelines")
+check "GET /pipelines without auth returns 401" "401" "$NO_AUTH"
+
+BAD_TOKEN=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY/pipelines" \
+  -H "Authorization: Bearer this.is.invalid")
+check "GET /pipelines with invalid JWT returns 401" "401" "$BAD_TOKEN"
+
+# ── Protected routes — valid JWT ─────────────────────────────────────────────
+
+echo ""
+echo "--- JWT auth ---"
+
+if [ -n "$ACCESS_TOKEN" ]; then
+  PIPELINES=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY/pipelines" \
+    -H "Authorization: Bearer $ACCESS_TOKEN")
+  check "GET /pipelines with valid JWT passes auth (200 or 502 if config-service down)" \
+    "200\|502\|503" "$PIPELINES"
+else
+  red "Skipping JWT auth test — could not obtain access token"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── API key auth ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "--- API key auth ---"
+
+INVALID_KEY=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY/pipelines" \
+  -H "x-api-key: fm_invalidkey123")
+check "GET /pipelines with invalid API key returns 401" "401" "$INVALID_KEY"
+
+# ── Rate limiting ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "--- Rate limiting headers ---"
+
+if [ -n "$ACCESS_TOKEN" ]; then
+  RATE_HEADERS=$(curl -s -I "$GATEWAY/pipelines" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" | tr -d '\r')
+  check "GET /pipelines with JWT includes X-RateLimit-Limit header" \
+    "x-ratelimit-limit\|X-RateLimit-Limit" "$RATE_HEADERS"
+else
+  red "Skipping rate limit header test — no access token"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=================================="
+echo "Passed: $PASS  Failed: $FAIL"
+echo "=================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Re-exports `JwtModule` and `RedisModule` from `AuthModule` so NestJS can resolve `AuthGuard` dependencies in consuming modules (`IngestModule`, `ManagementModule`)
- Replaces `localhost` with `127.0.0.1` in `.env.example` and gateway `.env` — on Node 18, `localhost` resolves to `::1` (IPv6) before IPv4, causing `ECONNREFUSED` against Docker's IPv4-only port bindings
- Adds `smoke-test-gateway.sh` for manual end-to-end gateway verification

## Test plan
- [ ] `make infra-up && make auth-dev && make gateway-dev`
- [ ] `./smoke-test-gateway.sh` — all 8 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)