### PR TITLE
feat: real-time live event feed via WebSocket and Redis pub/sub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ CONFIG_SERVICE_URL="http://127.0.0.1:3005"
 INGESTION_SERVICE_URL="http://127.0.0.1:3001"
 PIPELINE_SERVICE_URL="http://127.0.0.1:3002"
 AUTH_SERVICE_URL="http://127.0.0.1:3004"
+ANALYTICS_SERVICE_URL="http://127.0.0.1:3006"
 
 # ─── Delivery service (Go) ───────────────────────────────────────────────────
 # URL of config-service for delivery to fetch destination credentials

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ grafana-open:
 # ─── Full stack ───────────────────────────────────────────────────────────────
 
 up:
-	$(COMPOSE) up -d
+	$(COMPOSE) up --build -d
 
 down:
 	$(COMPOSE) down

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,11 @@ auth-generate:
 gateway-dev:
 	pnpm --filter @flowmesh/api-gateway dev
 
+# ─── Analytics service ───────────────────────────────────────────────────────
+
+analytics-dev:
+	pnpm --filter @flowmesh/analytics dev
+
 # ─── Dashboard ───────────────────────────────────────────────────────────────
 
 dashboard-dev:
@@ -179,5 +184,5 @@ env-setup:
         delivery-dev delivery-build delivery-test delivery-test-race \
         config-dev config-migrate-create config-migrate config-generate gen-encryption-key \
         auth-dev auth-migrate-create auth-migrate auth-generate \
-        gateway-dev dashboard-dev \
+        gateway-dev analytics-dev dashboard-dev \
         test test-integration test-coverage test-watch install gen-jwt-secret env-setup

--- a/apps/analytics/nest-cli.json
+++ b/apps/analytics/nest-cli.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/apps/analytics/package.json
+++ b/apps/analytics/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@flowmesh/analytics",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "nest build",
+    "dev": "nest start --watch",
+    "start": "node dist/main.js",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@flowmesh/nestjs-common": "workspace:*",
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/config": "^4.0.4",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-socket.io": "^10.3.0",
+    "@nestjs/websockets": "^10.3.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "ioredis": "^5.3.2",
+    "jsonwebtoken": "^9.0.2",
+    "joi": "^18.1.2",
+    "nestjs-pino": "^3.5.0",
+    "pino": "8",
+    "pino-http": "^8.6.1",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.1",
+    "socket.io": "^4.7.4"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.0",
+    "@nestjs/testing": "^10.3.0",
+    "@types/jsonwebtoken": "^9.0.5",
+    "@types/node": "^20.11.0",
+    "pino-pretty": "^10.3.1",
+    "typescript": "^5.3.0"
+  }
+}

--- a/apps/analytics/src/app.module.ts
+++ b/apps/analytics/src/app.module.ts
@@ -1,0 +1,47 @@
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common'
+import { LoggerModule } from 'nestjs-pino'
+import { AppConfigModule } from './config/config.module'
+import { RedisModule } from './redis/redis.module'
+import { EventsModule } from './events/events.module'
+import {
+  HealthModule,
+  HttpExceptionFilter,
+  CorrelationIdMiddleware,
+  CORRELATION_ID_HEADER,
+} from '@flowmesh/nestjs-common'
+
+const isDev = process.env.NODE_ENV !== 'production'
+
+@Module({
+  imports: [
+    AppConfigModule,
+    LoggerModule.forRoot({
+      pinoHttp: {
+        level: isDev ? 'debug' : 'info',
+        transport: isDev
+          ? { target: 'pino-pretty', options: { colorize: true, singleLine: true } }
+          : undefined,
+        serializers: {
+          req: (req) => ({ method: req.method, url: req.url }),
+          res: (res) => ({ statusCode: res.statusCode }),
+        },
+        customProps: (req) => ({
+          service: 'analytics',
+          correlationId: req.headers[CORRELATION_ID_HEADER],
+        }),
+        autoLogging: {
+          ignore: (req) => req.url === '/health',
+        },
+      },
+    }),
+    RedisModule,
+    EventsModule,
+    HealthModule,
+  ],
+  providers: [HttpExceptionFilter],
+})
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*')
+  }
+}

--- a/apps/analytics/src/config/config.module.ts
+++ b/apps/analytics/src/config/config.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import Joi from 'joi'
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      validationSchema: Joi.object({
+        NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
+        PORT: Joi.number().default(3006),
+        REDIS_EPHEMERAL_URL: Joi.string().required(),
+        JWT_SECRET: Joi.string().required(),
+      }),
+      validationOptions: { abortEarly: false },
+    }),
+  ],
+})
+export class AppConfigModule {}

--- a/apps/analytics/src/events/events.gateway.ts
+++ b/apps/analytics/src/events/events.gateway.ts
@@ -1,0 +1,99 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayInit,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  MessageBody,
+  ConnectedSocket,
+} from '@nestjs/websockets'
+import { Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Server, Socket } from 'socket.io'
+import * as jwt from 'jsonwebtoken'
+import { RedisService } from '../redis/redis.service'
+
+interface AccessTokenPayload {
+  sub: string
+  workspaceId: string
+  type: string
+}
+
+const LIVE_EVENTS_PATTERN = 'flowmesh:live:*'
+
+@WebSocketGateway({
+  cors: { origin: '*', credentials: true },
+  namespace: '/events',
+})
+export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server!: Server
+
+  private readonly logger = new Logger(EventsGateway.name)
+
+  constructor(
+    private readonly redis: RedisService,
+    private readonly config: ConfigService,
+  ) {}
+
+  afterInit() {
+    this.logger.log('WebSocket gateway initialised')
+    this.startRedisSubscription()
+  }
+
+  private startRedisSubscription() {
+    void this.redis.psubscribe(LIVE_EVENTS_PATTERN, (channel, message) => {
+      // channel format: flowmesh:live:{workspaceId}
+      const workspaceId = channel.split(':')[2]
+      if (!workspaceId) return
+
+      let event: unknown
+      try {
+        event = JSON.parse(message)
+      } catch {
+        return
+      }
+
+      // Emit to the workspace room — only clients that joined this workspace receive it
+      this.server.to(`workspace:${workspaceId}`).emit('event', event)
+    })
+  }
+
+  handleConnection(client: Socket) {
+    const token =
+      (client.handshake.auth as Record<string, string>)?.token ??
+      client.handshake.headers?.authorization?.replace('Bearer ', '')
+
+    if (!token) {
+      this.logger.warn({ socketId: client.id }, 'ws connection rejected — no token')
+      client.disconnect()
+      return
+    }
+
+    try {
+      const payload = jwt.verify(token, this.config.get<string>('JWT_SECRET')!) as AccessTokenPayload
+      if (payload.type !== 'access') throw new Error('wrong token type')
+
+      // Tag the socket with the workspaceId so subscribe message can use it
+      client.data.workspaceId = payload.workspaceId
+      this.logger.log({ socketId: client.id, workspaceId: payload.workspaceId }, 'ws client connected')
+    } catch {
+      this.logger.warn({ socketId: client.id }, 'ws connection rejected — invalid token')
+      client.disconnect()
+    }
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log({ socketId: client.id }, 'ws client disconnected')
+  }
+
+  @SubscribeMessage('subscribe')
+  handleSubscribe(@ConnectedSocket() client: Socket, @MessageBody() _data: unknown) {
+    const workspaceId = client.data.workspaceId as string | undefined
+    if (!workspaceId) return
+
+    void client.join(`workspace:${workspaceId}`)
+    this.logger.log({ socketId: client.id, workspaceId }, 'client subscribed to workspace events')
+  }
+}

--- a/apps/analytics/src/events/events.module.ts
+++ b/apps/analytics/src/events/events.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common'
+import { EventsGateway } from './events.gateway'
+
+@Module({
+  providers: [EventsGateway],
+})
+export class EventsModule {}

--- a/apps/analytics/src/main.ts
+++ b/apps/analytics/src/main.ts
@@ -1,0 +1,41 @@
+import { NestFactory } from '@nestjs/core'
+import { ValidationPipe } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Logger } from 'nestjs-pino'
+import { AppModule } from './app.module'
+import { HttpExceptionFilter } from '@flowmesh/nestjs-common'
+
+const DRAIN_DELAY_MS = 5000
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, { bufferLogs: true })
+  const config = app.get(ConfigService)
+
+  app.useLogger(app.get(Logger))
+  app.useGlobalFilters(app.get(HttpExceptionFilter))
+  app.useGlobalPipes(new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+  }))
+
+  app.enableCors({ origin: '*', credentials: true })
+
+  const logger = app.get(Logger)
+
+  process.on('SIGTERM', async () => {
+    logger.log('SIGTERM received — draining connections', 'Analytics')
+    await new Promise((resolve) => setTimeout(resolve, DRAIN_DELAY_MS))
+    await app.close()
+  })
+
+  process.on('SIGINT', async () => {
+    await app.close()
+  })
+
+  const port = config.get<number>('PORT')!
+  await app.listen(port, '0.0.0.0')
+  logger.log(`Analytics service listening on port ${port}`, 'Analytics')
+}
+
+bootstrap()

--- a/apps/analytics/src/redis/redis.module.ts
+++ b/apps/analytics/src/redis/redis.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common'
+import { RedisService } from './redis.service'
+
+@Global()
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/apps/analytics/src/redis/redis.service.ts
+++ b/apps/analytics/src/redis/redis.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common'
+import { Injectable, OnModuleDestroy, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import Redis from 'ioredis'
 
@@ -9,14 +9,12 @@ const BASE_DELAY_MS = 500
 const MAX_DELAY_MS = 30000
 
 @Injectable()
-export class RedisService implements OnModuleInit, OnModuleDestroy {
-  private subscriber!: Redis
+export class RedisService implements OnModuleDestroy {
+  private readonly subscriber: Redis
   private readonly logger = new Logger(RedisService.name)
 
-  constructor(private readonly config: ConfigService) {}
-
-  onModuleInit() {
-    const url = this.config.get<string>('REDIS_EPHEMERAL_URL')!
+  constructor(config: ConfigService) {
+    const url = config.get<string>('REDIS_EPHEMERAL_URL')!
 
     this.subscriber = new Redis(url, {
       maxRetriesPerRequest: null,

--- a/apps/analytics/src/redis/redis.service.ts
+++ b/apps/analytics/src/redis/redis.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import Redis from 'ioredis'
+
+export type RedisSubscribeCallback = (channel: string, message: string) => void
+
+const MAX_RETRY_ATTEMPTS = 10
+const BASE_DELAY_MS = 500
+const MAX_DELAY_MS = 30000
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+  private subscriber!: Redis
+  private readonly logger = new Logger(RedisService.name)
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    const url = this.config.get<string>('REDIS_EPHEMERAL_URL')!
+
+    this.subscriber = new Redis(url, {
+      maxRetriesPerRequest: null,
+      lazyConnect: false,
+      retryStrategy: (attempt) => {
+        if (attempt > MAX_RETRY_ATTEMPTS) return null
+        return Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS)
+      },
+    })
+
+    this.subscriber.on('connect', () => this.logger.log('connected to redis (ephemeral subscriber)'))
+    this.subscriber.on('error', (err) => this.logger.error({ err }, 'redis subscriber error'))
+  }
+
+  async onModuleDestroy() {
+    await this.subscriber.quit()
+  }
+
+  async subscribe(channel: string, callback: RedisSubscribeCallback): Promise<void> {
+    await this.subscriber.subscribe(channel)
+    this.subscriber.on('message', (ch, message) => {
+      if (ch === channel) callback(ch, message)
+    })
+  }
+
+  async psubscribe(pattern: string, callback: RedisSubscribeCallback): Promise<void> {
+    await this.subscriber.psubscribe(pattern)
+    this.subscriber.on('pmessage', (_pattern, channel, message) => {
+      callback(channel, message)
+    })
+  }
+}

--- a/apps/analytics/tsconfig.json
+++ b/apps/analytics/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/api-gateway/src/config/config.module.ts
+++ b/apps/api-gateway/src/config/config.module.ts
@@ -16,6 +16,7 @@ import Joi from 'joi'
         CONFIG_SERVICE_URL: Joi.string().required(),
         AUTH_SERVICE_URL: Joi.string().required(),
         PIPELINE_SERVICE_URL: Joi.string().required(),
+        ANALYTICS_SERVICE_URL: Joi.string().required(),
         RATE_LIMIT_INGEST_RPM: Joi.number().default(1000),
         RATE_LIMIT_MGMT_RPM: Joi.number().default(100),
       }),

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -19,6 +19,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",
+    "socket.io-client": "^4.7.4",
     "zod": "^4.4.2",
     "zod-formik-adapter": "^2.0.0"
   },

--- a/apps/dashboard/src/hooks/useEventStream.ts
+++ b/apps/dashboard/src/hooks/useEventStream.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
+import { io, Socket } from 'socket.io-client'
+import { getToken } from '../lib/auth'
+
+export interface LiveEvent {
+  id: string
+  eventId: string
+  eventName: string
+  source: string
+  userId: string | null
+  anonymousId: string | null
+  correlationId: string
+  properties: Record<string, unknown>
+  receivedAt: string
+  workspaceId: string
+}
+
+type ConnectionStatus = 'connecting' | 'connected' | 'disconnected'
+
+const ANALYTICS_URL = import.meta.env.VITE_ANALYTICS_URL ?? 'http://localhost:3006'
+const MAX_LIVE_EVENTS = 100
+
+export function useEventStream() {
+  const [liveEvents, setLiveEvents] = useState<LiveEvent[]>([])
+  const [status, setStatus] = useState<ConnectionStatus>('connecting')
+  const socketRef = useRef<Socket | null>(null)
+
+  useEffect(() => {
+    const token = getToken()
+    if (!token) {
+      setStatus('disconnected')
+      return
+    }
+
+    const socket = io(`${ANALYTICS_URL}/events`, {
+      auth: { token },
+      transports: ['websocket'],
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 10000,
+    })
+
+    socketRef.current = socket
+
+    socket.on('connect', () => {
+      setStatus('connected')
+      socket.emit('subscribe')
+    })
+
+    socket.on('disconnect', () => setStatus('disconnected'))
+    socket.on('connect_error', () => setStatus('disconnected'))
+
+    socket.on('event', (event: LiveEvent) => {
+      setLiveEvents((prev) => {
+        const next = [event, ...prev]
+        return next.length > MAX_LIVE_EVENTS ? next.slice(0, MAX_LIVE_EVENTS) : next
+      })
+    })
+
+    return () => {
+      socket.disconnect()
+    }
+  }, [])
+
+  return { liveEvents, status }
+}

--- a/apps/dashboard/src/hooks/useEventStream.ts
+++ b/apps/dashboard/src/hooks/useEventStream.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { io, Socket } from 'socket.io-client'
-import { getToken } from '../lib/auth'
+import axios from 'axios'
+import { getToken, getRefreshToken, setTokens, clearTokens } from '../lib/auth'
 
 export interface LiveEvent {
   id: string
@@ -20,10 +21,26 @@ type ConnectionStatus = 'connecting' | 'connected' | 'disconnected'
 const ANALYTICS_URL = import.meta.env.VITE_ANALYTICS_URL ?? 'http://localhost:3006'
 const MAX_LIVE_EVENTS = 100
 
+async function refreshAccessToken(): Promise<string | null> {
+  try {
+    const refreshToken = getRefreshToken()
+    if (!refreshToken) return null
+    const { data } = await axios.post<{ accessToken: string; refreshToken: string }>(
+      '/api/auth/refresh',
+      { refreshToken },
+    )
+    setTokens(data.accessToken, data.refreshToken)
+    return data.accessToken
+  } catch {
+    return null
+  }
+}
+
 export function useEventStream() {
   const [liveEvents, setLiveEvents] = useState<LiveEvent[]>([])
   const [status, setStatus] = useState<ConnectionStatus>('connecting')
   const socketRef = useRef<Socket | null>(null)
+  const refreshAttempted = useRef(false)
 
   useEffect(() => {
     const token = getToken()
@@ -35,19 +52,58 @@ export function useEventStream() {
     const socket = io(`${ANALYTICS_URL}/events`, {
       auth: { token },
       transports: ['websocket'],
+      // Let socket.io auto-reconnect on network drops (ping timeout, transport close)
+      reconnection: true,
       reconnectionDelay: 1000,
-      reconnectionDelayMax: 10000,
+      reconnectionDelayMax: 15000,
     })
 
     socketRef.current = socket
 
     socket.on('connect', () => {
+      refreshAttempted.current = false
       setStatus('connected')
       socket.emit('subscribe')
     })
 
-    socket.on('disconnect', () => setStatus('disconnected'))
-    socket.on('connect_error', () => setStatus('disconnected'))
+    socket.on('disconnect', (reason) => {
+      // Server-initiated disconnect means auth was rejected — stop reconnecting,
+      // try a token refresh, then reconnect manually.
+      if (reason === 'io server disconnect') {
+        socket.io.opts.reconnection = false
+        setStatus('disconnected')
+        refreshAccessToken().then((newToken) => {
+          if (newToken) {
+            socket.auth = { token: newToken }
+            socket.io.opts.reconnection = true
+            socket.connect()
+          } else {
+            clearTokens()
+            window.location.href = '/login'
+          }
+        })
+      } else {
+        // Network drop — socket.io auto-reconnects, show connecting state
+        setStatus('connecting')
+      }
+    })
+
+    socket.on('connect_error', async () => {
+      // Fires when a connection attempt fails (e.g. token expired before first connect)
+      if (!refreshAttempted.current) {
+        refreshAttempted.current = true
+        const newToken = await refreshAccessToken()
+        if (newToken) {
+          socket.auth = { token: newToken }
+          // socket.io will retry automatically — no need to call socket.connect()
+        } else {
+          socket.disconnect()
+          clearTokens()
+          window.location.href = '/login'
+        }
+      }
+      setStatus('connecting')
+    })
 
     socket.on('event', (event: LiveEvent) => {
       setLiveEvents((prev) => {

--- a/apps/dashboard/src/pages/events/EventsPage.tsx
+++ b/apps/dashboard/src/pages/events/EventsPage.tsx
@@ -35,14 +35,14 @@ function formatRelative(iso: string): string {
   return new Date(iso).toLocaleDateString()
 }
 
-function EventRow({ event }: { event: Event | LiveEvent }) {
+function EventRow({ event, isLive }: { event: Event | LiveEvent; isLive?: boolean }) {
   const [expanded, setExpanded] = useState(false)
   const hasProperties = event.properties && Object.keys(event.properties).length > 0
 
   return (
     <>
       <tr
-        className="hover:bg-gray-50 cursor-pointer select-none"
+        className={`hover:bg-gray-50 cursor-pointer select-none${isLive ? ' bg-emerald-50/40' : ''}`}
         onClick={() => setExpanded((e) => !e)}
       >
         <td className="px-4 py-3 w-6">
@@ -162,9 +162,9 @@ export default function EventsPage() {
             onChange={(e) => handleSearch(e.target.value)}
             className="flex-1 text-sm outline-none placeholder-gray-400"
           />
-          {total > 0 && (
+          {(total > 0 || newLiveEvents.length > 0) && (
             <span className="text-xs text-gray-400 whitespace-nowrap">
-              {total.toLocaleString()} event{total !== 1 ? 's' : ''}
+              {(total + newLiveEvents.length).toLocaleString()} event{total + newLiveEvents.length !== 1 ? 's' : ''}
             </span>
           )}
         </div>
@@ -202,7 +202,11 @@ export default function EventsPage() {
               </thead>
               <tbody className="divide-y divide-gray-50">
                 {displayEvents.map((event) => (
-                  <EventRow key={event.eventId} event={event} />
+                  <EventRow
+                    key={event.eventId}
+                    event={event}
+                    isLive={newLiveEvents.some((e) => e.eventId === event.eventId)}
+                  />
                 ))}
               </tbody>
             </table>

--- a/apps/dashboard/src/pages/events/EventsPage.tsx
+++ b/apps/dashboard/src/pages/events/EventsPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Search, ChevronDown, ChevronRight, RefreshCw, Zap } from 'lucide-react'
+import { Search, ChevronDown, ChevronRight, Zap, Wifi, WifiOff } from 'lucide-react'
 import api from '../../lib/api'
+import { useEventStream, type LiveEvent } from '../../hooks/useEventStream'
 
 interface Event {
   id: string
@@ -34,7 +35,7 @@ function formatRelative(iso: string): string {
   return new Date(iso).toLocaleDateString()
 }
 
-function EventRow({ event }: { event: Event }) {
+function EventRow({ event }: { event: Event | LiveEvent }) {
   const [expanded, setExpanded] = useState(false)
   const hasProperties = event.properties && Object.keys(event.properties).length > 0
 
@@ -91,6 +92,8 @@ export default function EventsPage() {
   const [offset, setOffset] = useState(0)
   const limit = 50
 
+  const { liveEvents, status } = useEventStream()
+
   function handleSearch(value: string) {
     setSearch(value)
     clearTimeout((handleSearch as unknown as { timer?: ReturnType<typeof setTimeout> }).timer)
@@ -100,7 +103,7 @@ export default function EventsPage() {
     }, 400)
   }
 
-  const { data, isLoading, error, refetch, isFetching } = useQuery<EventsResponse>({
+  const { data, isLoading, error } = useQuery<EventsResponse>({
     queryKey: ['events', debouncedSearch, offset],
     queryFn: () => {
       const params = new URLSearchParams()
@@ -109,26 +112,44 @@ export default function EventsPage() {
       if (debouncedSearch) params.set('search', debouncedSearch)
       return api.get<EventsResponse>(`/events?${params}`).then((r) => r.data)
     },
-    refetchInterval: 10000,
   })
 
-  const events = data?.events ?? []
+  const storedEvents = data?.events ?? []
   const total = data?.total ?? 0
   const pages = Math.ceil(total / limit)
   const currentPage = Math.floor(offset / limit) + 1
+
+  // When searching or paginating, show only REST results.
+  // On the first page with no search, prepend live events (deduped against REST results).
+  const isLivePage = !debouncedSearch && offset === 0
+  const storedIds = new Set(storedEvents.map((e) => e.eventId))
+  const newLiveEvents = isLivePage ? liveEvents.filter((e) => !storedIds.has(e.eventId)) : []
+  const displayEvents: (Event | LiveEvent)[] = [...newLiveEvents, ...storedEvents]
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-semibold text-gray-900">Events</h1>
-        <button
-          onClick={() => refetch()}
-          disabled={isFetching}
-          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 disabled:opacity-50 transition-colors"
-        >
-          <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
-          Refresh
-        </button>
+        <div className="flex items-center gap-2">
+          {status === 'connected' ? (
+            <span className="flex items-center gap-1.5 text-xs text-emerald-600 font-medium">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+              </span>
+              Live
+            </span>
+          ) : (
+            <span className="flex items-center gap-1.5 text-xs text-gray-400">
+              {status === 'connecting' ? (
+                <Wifi className="w-3.5 h-3.5 animate-pulse" />
+              ) : (
+                <WifiOff className="w-3.5 h-3.5" />
+              )}
+              {status === 'connecting' ? 'Connecting…' : 'Offline'}
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden">
@@ -154,7 +175,7 @@ export default function EventsPage() {
           <div className="py-16 text-center text-sm text-red-500">
             Failed to load events — make sure the ingestion service is running.
           </div>
-        ) : events.length === 0 ? (
+        ) : displayEvents.length === 0 ? (
           <div className="py-16 text-center">
             <div className="w-12 h-12 bg-indigo-50 rounded-full flex items-center justify-center mx-auto mb-3">
               <Zap className="w-6 h-6 text-indigo-500" />
@@ -180,8 +201,8 @@ export default function EventsPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-50">
-                {events.map((event) => (
-                  <EventRow key={event.id} event={event} />
+                {displayEvents.map((event) => (
+                  <EventRow key={event.eventId} event={event} />
                 ))}
               </tbody>
             </table>

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/ingestion/src/config/config.module.spec.ts
+++ b/apps/ingestion/src/config/config.module.spec.ts
@@ -7,17 +7,24 @@ const makeEnv = () => ({
   DATABASE_URL: 'postgresql://flowmesh:test@localhost:5433/flowmesh?schema=ingestion',
   RABBITMQ_URL: 'amqp://flowmesh:test@localhost:5672/flowmesh',
   REDIS_PERSISTENT_URL: 'redis://localhost:6380',
+  REDIS_EPHEMERAL_URL: 'redis://localhost:6379',
 })
 
 describe('appConfigValidationSchema', () => {
-  it('does not require REDIS_EPHEMERAL_URL for ingestion', () => {
-    const { error, value } = appConfigValidationSchema.validate(makeEnv())
-
+  it('accepts a valid ingestion config', () => {
+    const { error } = appConfigValidationSchema.validate(makeEnv())
     expect(error).toBeUndefined()
-    expect(value.REDIS_EPHEMERAL_URL).toBeUndefined()
   })
 
-  it('still requires REDIS_PERSISTENT_URL for ingestion idempotency storage', () => {
+  it('requires REDIS_EPHEMERAL_URL for live event pub/sub', () => {
+    const { REDIS_EPHEMERAL_URL: _unused, ...env } = makeEnv()
+    const { error } = appConfigValidationSchema.validate(env)
+
+    expect(error).toBeDefined()
+    expect(error?.details.map((detail) => detail.path.join('.'))).toContain('REDIS_EPHEMERAL_URL')
+  })
+
+  it('requires REDIS_PERSISTENT_URL for idempotency storage', () => {
     const { REDIS_PERSISTENT_URL: _unused, ...env } = makeEnv()
     const { error } = appConfigValidationSchema.validate(env)
 

--- a/apps/ingestion/src/config/validation.schema.ts
+++ b/apps/ingestion/src/config/validation.schema.ts
@@ -24,4 +24,5 @@ export const appConfigValidationSchema = Joi.object({
   DATABASE_URL: postgresUrlWithSchema('ingestion'),
   RABBITMQ_URL: Joi.string().required(),
   REDIS_PERSISTENT_URL: Joi.string().required(),
+  REDIS_EPHEMERAL_URL: Joi.string().required(),
 })

--- a/apps/ingestion/src/ingestion/ingestion.service.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.spec.ts
@@ -5,6 +5,7 @@ import { IngestionService } from './ingestion.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { RabbitMQService } from '../rabbitmq/rabbitmq.service'
 import { RedisService } from '../redis/redis.service'
+import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 
 const mockLogger = {
@@ -34,6 +35,7 @@ describe('IngestionService', () => {
     isEventProcessed: ReturnType<typeof vi.fn>
     markEventProcessed: ReturnType<typeof vi.fn>
   }
+  let pubsub: { publishEvent: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     prisma = { event: { create: vi.fn().mockResolvedValue({}) } }
@@ -42,11 +44,13 @@ describe('IngestionService', () => {
       isEventProcessed: vi.fn().mockResolvedValue(false),
       markEventProcessed: vi.fn().mockResolvedValue(undefined),
     }
+    pubsub = { publishEvent: vi.fn().mockResolvedValue(undefined) }
 
     service = new IngestionService(
       prisma as unknown as PrismaService,
       rabbitmq as unknown as RabbitMQService,
       redis as unknown as RedisService,
+      pubsub as unknown as RedisPubSubService,
       mockLogger,
     )
   })

--- a/apps/ingestion/src/ingestion/ingestion.service.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.ts
@@ -4,6 +4,7 @@ import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 import { PrismaService } from '../prisma/prisma.service'
 import { RabbitMQService } from '../rabbitmq/rabbitmq.service'
 import { RedisService } from '../redis/redis.service'
+import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 import { QueryEventsDto } from './dto/query-events.dto'
 
@@ -18,6 +19,7 @@ export class IngestionService {
     private readonly prisma: PrismaService,
     private readonly rabbitmq: RabbitMQService,
     private readonly redis: RedisService,
+    private readonly pubsub: RedisPubSubService,
     @InjectPinoLogger(IngestionService.name) private readonly logger: PinoLogger,
   ) {}
 
@@ -116,6 +118,20 @@ export class IngestionService {
 
     // Mark as processed after successful publish
     await this.redis.markEventProcessed(eventId)
+
+    // Publish to live event feed (fire-and-forget — never block ingestion for this)
+    this.pubsub.publishEvent({
+      id: eventId,
+      eventId,
+      eventName: dto.event,
+      source: dto.source,
+      userId: dto.userId ?? null,
+      anonymousId: dto.anonymousId ?? null,
+      correlationId: dto.correlationId,
+      properties: dto.properties ?? {},
+      receivedAt: timestamp,
+      workspaceId,
+    }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
 
     this.logger.info({ eventId, correlationId: dto.correlationId, workspaceId, event: dto.event }, 'event accepted')
 

--- a/apps/ingestion/src/redis/redis-pubsub.service.ts
+++ b/apps/ingestion/src/redis/redis-pubsub.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import Redis from 'ioredis'
+
+const LIVE_EVENTS_CHANNEL = 'flowmesh:live'
+
+export interface LiveEvent {
+  id: string
+  eventId: string
+  eventName: string
+  source: string
+  userId: string | null
+  anonymousId: string | null
+  correlationId: string
+  properties: Record<string, unknown>
+  receivedAt: string
+  workspaceId: string
+}
+
+@Injectable()
+export class RedisPubSubService implements OnModuleInit, OnModuleDestroy {
+  private publisher!: Redis
+
+  constructor(
+    private readonly config: ConfigService,
+    @InjectPinoLogger(RedisPubSubService.name) private readonly logger: PinoLogger,
+  ) {}
+
+  onModuleInit() {
+    const url = this.config.get<string>('REDIS_EPHEMERAL_URL')!
+    this.publisher = new Redis(url, { maxRetriesPerRequest: 3, lazyConnect: false })
+
+    this.publisher.on('connect', () => this.logger.info('connected to redis (ephemeral pubsub)'))
+    this.publisher.on('error', (err) => this.logger.error({ err }, 'redis ephemeral error'))
+  }
+
+  async onModuleDestroy() {
+    await this.publisher.quit()
+  }
+
+  async publishEvent(event: LiveEvent): Promise<void> {
+    const channel = `${LIVE_EVENTS_CHANNEL}:${event.workspaceId}`
+    await this.publisher.publish(channel, JSON.stringify(event))
+  }
+}

--- a/apps/ingestion/src/redis/redis.module.ts
+++ b/apps/ingestion/src/redis/redis.module.ts
@@ -1,9 +1,10 @@
 import { Module, Global } from '@nestjs/common'
 import { RedisService } from './redis.service'
+import { RedisPubSubService } from './redis-pubsub.service'
 
 @Global()
 @Module({
-  providers: [RedisService],
-  exports: [RedisService],
+  providers: [RedisService, RedisPubSubService],
+  exports: [RedisService, RedisPubSubService],
 })
 export class RedisModule {}

--- a/docker/Dockerfile.nestjs
+++ b/docker/Dockerfile.nestjs
@@ -32,6 +32,7 @@ COPY apps/pipeline/package.json       ./apps/pipeline/
 COPY apps/auth/package.json           ./apps/auth/
 COPY apps/config-service/package.json ./apps/config-service/
 COPY apps/api-gateway/package.json    ./apps/api-gateway/
+COPY apps/analytics/package.json      ./apps/analytics/
 
 RUN pnpm install --frozen-lockfile
 
@@ -77,6 +78,7 @@ COPY --from=deps /app/apps/pipeline/package.json       ./apps/pipeline/
 COPY --from=deps /app/apps/auth/package.json           ./apps/auth/
 COPY --from=deps /app/apps/config-service/package.json ./apps/config-service/
 COPY --from=deps /app/apps/api-gateway/package.json    ./apps/api-gateway/
+COPY --from=deps /app/apps/analytics/package.json      ./apps/analytics/
 
 RUN pnpm install --frozen-lockfile --prod
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -66,7 +66,11 @@ services:
 
   analytics:
     build:
-      target: development
+      context: ..
+      dockerfile: docker/Dockerfile.nestjs
+      args:
+        SERVICE_NAME: analytics
+        SERVICE_PORT: 3006
     volumes:
       - ../apps/analytics:/app
       - /app/node_modules

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -130,6 +130,7 @@ services:
       CONFIG_SERVICE_URL: http://config-service:3005
       AUTH_SERVICE_URL: http://auth:3004
       PIPELINE_SERVICE_URL: http://pipeline:3002
+      ANALYTICS_SERVICE_URL: http://analytics:3006
       REDIS_EPHEMERAL_URL: redis://redis-ephemeral:6379
       REDIS_PERSISTENT_URL: redis://redis-persistent:6379
     ports:
@@ -265,22 +266,27 @@ services:
     networks:
       - flowmesh
 
-  # analytics and alert are Phase 3 — not yet implemented.
-  # Uncomment when their Dockerfiles exist.
-  #
-  # analytics:
-  #   build:
-  #     context: ../apps/analytics
-  #     dockerfile: Dockerfile
-  #   container_name: flowmesh-analytics
-  #   environment:
-  #     PORT: 3006
-  #     DATABASE_URL: postgresql://flowmesh:${POSTGRES_PASSWORD}@pgbouncer:5432/flowmesh
-  #     RABBITMQ_URL: amqp://flowmesh:${RABBITMQ_PASSWORD}@rabbitmq:5672/flowmesh
-  #     REDIS_EPHEMERAL_URL: redis://redis-ephemeral:6379
-  #   networks:
-  #     - flowmesh
-  #
+  analytics:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.nestjs
+      args:
+        SERVICE_NAME: analytics
+        SERVICE_PORT: 3006
+    container_name: flowmesh-analytics
+    restart: unless-stopped
+    env_file: ../.env
+    environment:
+      PORT: 3006
+      REDIS_EPHEMERAL_URL: redis://redis-ephemeral:6379
+    ports:
+      - "3006:3006"
+    depends_on:
+      redis-ephemeral:
+        condition: service_healthy
+    networks:
+      - flowmesh
+
   # alert:
   #   build:
   #     context: ../apps/alert

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,79 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.39)
 
+  apps/analytics:
+    dependencies:
+      '@flowmesh/nestjs-common':
+        specifier: workspace:*
+        version: link:../../packages/nestjs-common
+      '@nestjs/common':
+        specifier: ^10.3.0
+        version: 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config':
+        specifier: ^4.0.4
+        version: 4.0.4(@nestjs/common@10.4.22)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-socket.io':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22)(@nestjs/websockets@10.4.22)(rxjs@7.8.2)
+      '@nestjs/websockets':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.14.1
+        version: 0.14.4
+      ioredis:
+        specifier: ^5.3.2
+        version: 5.10.1
+      joi:
+        specifier: ^18.1.2
+        version: 18.1.2
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
+      nestjs-pino:
+        specifier: ^3.5.0
+        version: 3.5.0(@nestjs/common@10.4.22)(pino-http@8.6.1)
+      pino:
+        specifier: '8'
+        version: 8.21.0
+      pino-http:
+        specifier: ^8.6.1
+        version: 8.6.1
+      reflect-metadata:
+        specifier: 0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+      socket.io:
+        specifier: ^4.7.4
+        version: 4.8.3
+    devDependencies:
+      '@nestjs/cli':
+        specifier: ^10.3.0
+        version: 10.4.9(@swc/core@1.15.30)
+      '@nestjs/testing':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)
+      '@types/jsonwebtoken':
+        specifier: ^9.0.5
+        version: 9.0.5
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.39
+      pino-pretty:
+        specifier: ^10.3.1
+        version: 10.3.1
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   apps/api-gateway:
     dependencies:
       '@flowmesh/nestjs-common':
@@ -299,6 +372,9 @@ importers:
       react-router-dom:
         specifier: ^6.22.0
         version: 6.30.3(react-dom@18.3.1)(react@18.3.1)
+      socket.io-client:
+        specifier: ^4.7.4
+        version: 4.8.3
       zod:
         specifier: ^4.4.2
         version: 4.4.2
@@ -1435,6 +1511,37 @@ packages:
     transitivePeerDependencies:
       - encoding
 
+  /@nestjs/core@10.4.22(@nestjs/common@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+    resolution: {integrity: sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==}
+    requiresBuild: true
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/microservices': ^10.0.0
+      '@nestjs/platform-express': ^10.0.0
+      '@nestjs/websockets': ^10.0.0
+      reflect-metadata: 0.2.2
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+      '@nestjs/websockets':
+        optional: true
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/websockets': 10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nuxtjs/opencollective': 0.3.2
+      fast-safe-stringify: 2.1.1
+      iterare: 1.2.1
+      path-to-regexp: 3.3.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - encoding
+
   /@nestjs/jwt@10.2.0(@nestjs/common@10.4.22):
     resolution: {integrity: sha512-x8cG90SURkEiLOehNaN2aRlotxT0KZESUliOPKKnjWiyJOcWurkF3w345WOX0P4MgFzUjGoZ1Sy0aZnxeihT0g==}
     peerDependencies:
@@ -1461,6 +1568,23 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@nestjs/platform-socket.io@10.4.22(@nestjs/common@10.4.22)(@nestjs/websockets@10.4.22)(rxjs@7.8.2):
+    resolution: {integrity: sha512-xxGw3R0Ihr51/Omq23z3//bKmCXyVKaikxbH0/pkwqMsQrxkUv9NabNUZ22b4Jnlwwi02X+zlwo8GRa9u8oV9g==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/websockets': ^10.0.0
+      rxjs: ^7.1.0
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/websockets': 10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      rxjs: 7.8.2
+      socket.io: 4.8.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   /@nestjs/schematics@10.2.3(chokidar@3.6.0)(typescript@5.7.2):
     resolution: {integrity: sha512-4e8gxaCk7DhBxVUly2PjYL4xC2ifDFexCqq1/u4TtivLGXotVk0wHdYuPYe1tHTHuR1lsOkRbfOCpkdTnigLVg==}
     peerDependencies:
@@ -1474,6 +1598,24 @@ packages:
       typescript: 5.7.2
     transitivePeerDependencies:
       - chokidar
+    dev: true
+
+  /@nestjs/testing@10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22):
+    resolution: {integrity: sha512-HO9aPus3bAedAC+jKVAA8jTdaj4fs5M9fing4giHrcYV2txe9CvC1l1WAjwQ9RDhEHdugjY4y+FZA/U/YqPZrA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/core': ^10.0.0
+      '@nestjs/microservices': ^10.0.0
+      '@nestjs/platform-express': ^10.0.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      tslib: 2.8.1
     dev: true
 
   /@nestjs/testing@10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22):
@@ -1494,6 +1636,27 @@ packages:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)
       tslib: 2.8.1
     dev: true
+
+  /@nestjs/websockets@10.4.22(@nestjs/common@10.4.22)(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+    resolution: {integrity: sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/core': ^10.0.0
+      '@nestjs/platform-socket.io': ^10.0.0
+      reflect-metadata: 0.2.2
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/platform-socket.io':
+        optional: true
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-socket.io': 10.4.22(@nestjs/common@10.4.22)(@nestjs/websockets@10.4.22)(rxjs@7.8.2)
+      iterare: 1.2.1
+      object-hash: 3.0.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
 
   /@noble/hashes@1.8.0:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1834,6 +1997,9 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
+  /@socket.io/component-emitter@3.1.2:
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   /@standard-schema/spec@1.1.0:
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
     dev: false
@@ -2115,6 +2281,11 @@ packages:
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
     dev: true
 
+  /@types/cors@2.8.19:
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+    dependencies:
+      '@types/node': 20.19.39
+
   /@types/eslint-scope@3.7.7:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
@@ -2172,7 +2343,6 @@ packages:
     resolution: {integrity: sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==}
     dependencies:
       '@types/node': 20.19.39
-    dev: false
 
   /@types/methods@1.1.4:
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -2261,6 +2431,11 @@ packages:
 
   /@types/validator@13.15.10:
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
+  /@types/ws@8.18.1:
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+    dependencies:
+      '@types/node': 20.19.39
 
   /@vitejs/plugin-react@4.7.0(vite@5.4.21):
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -2716,6 +2891,10 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  /base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   /baseline-browser-mapping@2.10.21:
     resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
@@ -3213,6 +3392,17 @@ packages:
     dependencies:
       ms: 2.0.0
 
+  /debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+
   /debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -3369,6 +3559,43 @@ packages:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
     dependencies:
       once: 1.4.0
+
+  /engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  /engine.io@6.6.7:
+    resolution: {integrity: sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 20.19.39
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.5
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   /enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
@@ -4738,7 +4965,6 @@ packages:
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -5488,6 +5714,72 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
     dev: true
+
+  /socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
+    dependencies:
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  /socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  /socket.io@4.8.1:
+    resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.3.7
+      engine.io: 6.6.7
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  /socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.4.3
+      engine.io: 6.6.7
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
 
   /sonic-boom@3.8.1:
     resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
@@ -6249,6 +6541,23 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  /ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  /xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
 
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}


### PR DESCRIPTION
## Summary

- Ingestion publishes accepted events to Redis ephemeral pub/sub (`flowmesh:live:{workspaceId}`)
- New `analytics` service subscribes with `psubscribe`, forwards messages to connected browser clients over Socket.IO (`/events` namespace), scoped to workspace rooms
- Dashboard `useEventStream` hook manages the Socket.IO connection with JWT auth, auto-reconnect on network drops, and token refresh on auth rejection
- Events page displays live events with a green highlight; event count includes live arrivals not yet absorbed by the REST query

## What changed

| Service | Change |
|---|---|
| `ingestion` | Publishes to `flowmesh:live:{workspaceId}` after every accepted event |
| `analytics` | New NestJS service — WebSocket gateway + Redis subscriber |
| `dashboard` | `useEventStream` hook, live event highlight, count fix |
| `docker` | Analytics added to `docker-compose.yml`, `Dockerfile.nestjs`, Makefile |

## Bugs fixed

- `RedisService` subscriber was initialised in `onModuleInit()` but the WebSocket gateway's `afterInit()` fires first — moved to constructor
- Analytics `package.json` was missing from both Dockerfile stages, causing `Cannot find module '@nestjs/websockets'` in Docker builds
- `make up` was reusing cached images — changed to always `--build`
- Live events were arriving but invisible because they had no visual distinction from stored events and the count stayed frozen at the REST total

## Test plan

- [ ] `make up` builds and starts all services including analytics on port 3006
- [ ] Dashboard Events page shows green "Live" indicator when WebSocket connects
- [ ] Sending a POST to `/ingest/events` causes a new row to appear at the top of the Events page with a green tint, without refreshing
- [ ] Event count in the search bar increments immediately on live arrival
- [ ] Letting the access token expire (15 min) causes an automatic token refresh and reconnect — no manual logout required
- [ ] Navigating away from the Events page and back creates a fresh socket connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)