### PR TITLE
feat(ingestion): identify and alias event types + sdk-node v0.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,12 @@ Thank you for your interest in contributing. FlowMesh is an active open-source p
 | Config service — pipeline CRUD, encrypted destination credentials | ✅ Complete |
 | Dashboard — pipelines, destinations, events, pipeline builder, live feed, DLQ replay | ✅ Complete |
 | Analytics — WebSocket live feed | ✅ Complete |
+| Slack / Discord / S3 destinations | ✅ Complete |
+| Node.js SDK (`flowmesh-node` on npm) | ✅ Complete |
+| Identify + alias event types | ✅ Complete |
 | Alert service | 🔧 In progress |
-| Slack / S3 / Discord destinations | 🔧 In progress |
-| Node.js SDK | ⬜ Not started |
+| Pipeline execution history | 🔧 Pre-launch |
+| Destination delivery status dashboard | 🔧 Pre-launch |
 
 ---
 
@@ -196,7 +199,7 @@ chore/<short-description>   # tooling, dependencies
 
 Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`
 
-Scopes: `ingestion`, `pipeline`, `delivery`, `auth`, `analytics`, `alert`, `config`, `gateway`, `dashboard`, `shared-types`, `nestjs-common`, `docker`, `makefile`, `ci`
+Scopes: `ingestion`, `pipeline`, `delivery`, `auth`, `analytics`, `alert`, `config`, `gateway`, `dashboard`, `sdk-node`, `shared-types`, `nestjs-common`, `docker`, `makefile`, `ci`
 
 Examples:
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 
 **Self-hostable, open-source real-time event pipeline platform.**
 
-FlowMesh replaces Segment + Mixpanel + PagerDuty in a single Docker deployment — fully open source, fully under your control, free forever.
+FlowMesh covers event capture, pipeline routing, real-time dashboards, and alerting — the core of what Segment, Mixpanel, and PagerDuty do for small and mid-size teams, self-hosted and free.
+
+> ⭐ If you are tired of paying $500–$20,000/month to Segment, Mixpanel, or PagerDuty —
+> star this repo so other developers can find it.
 
 ---
 
@@ -39,13 +42,15 @@ docker compose up
 
 Open source. Self-hosted. Free forever. No license keys. No feature flags. No artificial limits on events or destinations.
 
-Clone the repo, run one command, and have a full production event pipeline in 60 seconds. That is it.
+Clone the repo, run one command, and have a working event pipeline running locally in minutes. A production-hardened configuration — TLS termination, secure PgBouncer auth, and Traefik edge proxy — ships before the v1.0 launch.
 
 ## Features
 
 | Feature | Status |
 |---|---|
 | Event ingestion API (REST + SDK) | ✅ Available |
+| `identify()` — store user traits, link userId to profile | ✅ Available |
+| `alias()` — link anonymous visitor to known user at login | ✅ Available |
 | Schema validation and auto-generated correlation ID tracing | ✅ Available |
 | Idempotent event deduplication | ✅ Available |
 | RabbitMQ-backed event queue | ✅ Available |
@@ -72,9 +77,9 @@ Clone the repo, run one command, and have a full production event pipeline in 60
 
 **Docker Compose** — for solo developers and small teams. One server, one command. Runs comfortably on an $11/month Hetzner VPS.
 
-**Kubernetes + Helm** — for larger teams who want to self-host at scale with independent scaling per service. Also free and open source — we ship the Helm chart so you have the tools to do it properly.
+**Kubernetes + Helm** *(planned for v0.3)* — for teams self-hosting at scale with independent scaling per service. The Helm chart is on the roadmap — community edition, fully open source.
 
-Both deployment options are fully open source with no restrictions.
+Docker Compose is available today with no restrictions.
 
 ---
 
@@ -92,7 +97,7 @@ FlowMesh is a polyglot microservices platform. Each service has a single, clearl
 | Ingestion | NestJS + TypeScript | Receive events, validate, deduplicate, publish to queue |
 | Pipeline | NestJS + TypeScript | Execute filter / transform / enrich / fan-out |
 | Delivery | **Go** | Consume queue, deliver to destinations, circuit breaker, retry, DLQ |
-| Auth | NestJS + TypeScript | JWT, API keys, workspaces, RBAC |
+| Auth | NestJS + TypeScript | JWT, API keys, workspaces |
 | Analytics | NestJS + TypeScript | Aggregate metrics, serve dashboard data |
 | Alert | NestJS + TypeScript | Evaluate alert rules against event stream |
 | Config | NestJS + TypeScript | Store pipeline definitions and destination credentials |
@@ -113,11 +118,11 @@ FlowMesh is a polyglot microservices platform. Each service has a single, clearl
 
 ### Distributed Systems Patterns
 
-Every hard distributed systems problem in the event pipeline is solved explicitly:
+The core distributed systems problems in the event pipeline are solved explicitly:
 
 | Pattern | Where | Why |
 |---|---|---|
-| Rate limiting | API Gateway → Redis | Sliding window per API key |
+| Rate limiting | API Gateway → Redis | Fixed window per API key |
 | Idempotency | Ingestion → Redis | Deduplicate events by `eventId`, survives restarts |
 | Message queue | Ingestion → RabbitMQ → Pipeline | Decouple services, buffer during downstream outages |
 | Circuit breaker | Delivery | Stop cascade failures when Slack / Postgres / S3 is slow |
@@ -212,6 +217,15 @@ curl -X POST http://localhost:3000/ingest/events/batch \
 ---
 
 ## Event Schema
+
+FlowMesh exposes three ingestion endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /ingest/events` | Track a named event — page views, clicks, orders, anything |
+| `POST /ingest/events/identify` | Store traits for a known user (`name`, `email`, `plan`, etc.) |
+| `POST /ingest/events/alias` | Link an anonymous visitor ID to a known userId at login time |
+| `POST /ingest/events/batch` | Send up to 100 events in a single request |
 
 Every event sent to FlowMesh follows this structure:
 
@@ -384,7 +398,12 @@ The best ways to contribute right now:
 2. **Documentation** — improve examples, fix typos, add missing context
 3. **Tests** — increase coverage for edge cases
 4. **Alerting engine** — condition builder and rule evaluation against the event stream
-5. **Node.js SDK** — wraps the ingestion API for server-side use
+5. **Python SDK** — `pip install flowmesh`
+6. **PHP SDK** — `composer require flowmesh/sdk`
+7. **Laravel package** — service provider, `FlowMesh::track()` facade, artisan commands
+8. **NestJS module** — `FlowMeshModule.forRoot()` with `@InjectFlowMesh()` decorator
+9. **Go SDK** — for server-side Go applications
+10. **New destination drivers** — email (SMTP/Resend), PagerDuty, Datadog
 
 Please open an issue before starting significant work so we can discuss the approach.
 
@@ -418,11 +437,11 @@ make test-integration    # integration tests (requires Docker infra running)
 
 ---
 
-## FlowMesh Cloud
+## FlowMesh Cloud *(planned)*
 
-If you want FlowMesh without managing the infrastructure yourself, [FlowMesh Cloud](https://getflowmesh.com) is a hosted version — same pipeline, same SDK, no server to run.
+A hosted version of FlowMesh is planned — same pipeline, same SDK, no infrastructure to run. Designed for teams who want the power of FlowMesh without operating it themselves.
 
-The self-hosted open source version has no limitations. FlowMesh Cloud is for teams who prefer not to operate it themselves.
+The self-hosted community edition has no limitations and is the current focus. Cloud will follow based on community feedback.
 
 ---
 
@@ -455,6 +474,20 @@ Enterprise features are available on FlowMesh Cloud.
 
 ---
 
+## Support FlowMesh
+
+FlowMesh is built and maintained by one engineer in his spare time.
+
+If it saves you from a Segment bill or a 3am infrastructure incident —
+a GitHub star takes 2 seconds and helps other developers find it.
+
+⭐ [Star FlowMesh on GitHub](https://github.com/syedarifiqbal/flowmesh)
+
+Found a bug? [Open an issue](https://github.com/syedarifiqbal/flowmesh/issues)
+Want to contribute? [Read the contributing guide](CONTRIBUTING.md)
+
+---
+
 ## Author
 
 Built by [Arif Iqbal](https://syedarifiqbal.com) — Senior Full-Stack Engineer.
@@ -462,7 +495,3 @@ Built by [Arif Iqbal](https://syedarifiqbal.com) — Senior Full-Stack Engineer.
 - GitHub: [@syedarifiqbal](https://github.com/syedarifiqbal)
 - LinkedIn: [linkedin.com/in/syedarifiqbal](https://linkedin.com/in/syedarifiqbal)
 - Website: [syedarifiqbal.com](https://syedarifiqbal.com)
-
----
-
-*If FlowMesh solves a problem you have, give it a star — it helps more people find it.*

--- a/apps/ingestion/prisma/migrations/20260514000000_add_user_traits/migration.sql
+++ b/apps/ingestion/prisma/migrations/20260514000000_add_user_traits/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE ingestion.user_traits (
+    "id"           TEXT         NOT NULL,
+    "workspace_id" TEXT         NOT NULL,
+    "user_id"      TEXT         NOT NULL,
+    "anonymous_id" TEXT,
+    "traits"       JSONB        NOT NULL DEFAULT '{}',
+    "source"       TEXT         NOT NULL,
+    "version"      TEXT         NOT NULL,
+    "created_at"   TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"   TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_traits_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_traits_workspace_id_user_id_key" ON ingestion.user_traits ("workspace_id", "user_id");
+
+-- CreateIndex
+CREATE INDEX "user_traits_workspace_id_user_id_idx" ON ingestion.user_traits ("workspace_id", "user_id");

--- a/apps/ingestion/prisma/migrations/20260514000001_add_alias_map/migration.sql
+++ b/apps/ingestion/prisma/migrations/20260514000001_add_alias_map/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE ingestion.alias_map (
+    "id"           TEXT        NOT NULL,
+    "workspace_id" TEXT        NOT NULL,
+    "anonymous_id" TEXT        NOT NULL,
+    "user_id"      TEXT        NOT NULL,
+    "source"       TEXT        NOT NULL,
+    "version"      TEXT        NOT NULL,
+    "created_at"   TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "alias_map_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "alias_map_workspace_id_anonymous_id_key" ON ingestion.alias_map ("workspace_id", "anonymous_id");
+
+-- CreateIndex
+CREATE INDEX "alias_map_workspace_id_user_id_idx" ON ingestion.alias_map ("workspace_id", "user_id");

--- a/apps/ingestion/prisma/schema.prisma
+++ b/apps/ingestion/prisma/schema.prisma
@@ -29,3 +29,19 @@ model Event {
   @@index([workspaceId, eventName])
   @@map("events")
 }
+
+model UserTrait {
+  id          String   @id @default(uuid())
+  workspaceId String   @map("workspace_id")
+  userId      String   @map("user_id")
+  anonymousId String?  @map("anonymous_id")
+  traits      Json     @default("{}")
+  source      String
+  version     String
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@unique([workspaceId, userId])
+  @@index([workspaceId, userId])
+  @@map("user_traits")
+}

--- a/apps/ingestion/prisma/schema.prisma
+++ b/apps/ingestion/prisma/schema.prisma
@@ -45,3 +45,17 @@ model UserTrait {
   @@index([workspaceId, userId])
   @@map("user_traits")
 }
+
+model AliasMap {
+  id          String   @id @default(uuid())
+  workspaceId String   @map("workspace_id")
+  anonymousId String   @map("anonymous_id")
+  userId      String   @map("user_id")
+  source      String
+  version     String
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  @@unique([workspaceId, anonymousId])
+  @@index([workspaceId, userId])
+  @@map("alias_map")
+}

--- a/apps/ingestion/src/ingestion/dto/alias.dto.ts
+++ b/apps/ingestion/src/ingestion/dto/alias.dto.ts
@@ -1,0 +1,37 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsUUID,
+  IsISO8601,
+  IsOptional,
+} from 'class-validator'
+
+export class AliasDto {
+  @IsString()
+  @IsNotEmpty()
+  userId!: string
+
+  @IsString()
+  @IsNotEmpty()
+  anonymousId!: string
+
+  @IsUUID('4')
+  @IsOptional()
+  correlationId?: string
+
+  @IsUUID('4')
+  @IsOptional()
+  eventId?: string
+
+  @IsISO8601({ strict: true })
+  @IsOptional()
+  timestamp?: string
+
+  @IsString()
+  @IsNotEmpty()
+  source!: string
+
+  @IsString()
+  @IsNotEmpty()
+  version!: string
+}

--- a/apps/ingestion/src/ingestion/dto/identify.dto.ts
+++ b/apps/ingestion/src/ingestion/dto/identify.dto.ts
@@ -1,0 +1,46 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsUUID,
+  IsISO8601,
+  IsOptional,
+  IsObject,
+} from 'class-validator'
+
+export class IdentifyDto {
+  @IsString()
+  @IsNotEmpty()
+  userId!: string
+
+  @IsString()
+  @IsOptional()
+  anonymousId?: string
+
+  @IsUUID('4')
+  @IsOptional()
+  correlationId?: string
+
+  @IsUUID('4')
+  @IsOptional()
+  eventId?: string
+
+  @IsISO8601({ strict: true })
+  @IsOptional()
+  timestamp?: string
+
+  @IsString()
+  @IsNotEmpty()
+  source!: string
+
+  @IsString()
+  @IsNotEmpty()
+  version!: string
+
+  @IsObject()
+  @IsOptional()
+  traits?: Record<string, unknown>
+
+  @IsObject()
+  @IsOptional()
+  context?: Record<string, unknown>
+}

--- a/apps/ingestion/src/ingestion/ingestion.controller.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.controller.spec.ts
@@ -8,6 +8,7 @@ const mockService = {
   ingest: vi.fn(),
   ingestBatch: vi.fn(),
   identify: vi.fn(),
+  alias: vi.fn(),
   findAll: vi.fn(),
   getThroughput: vi.fn(),
 }
@@ -133,6 +134,40 @@ describe('IngestionController', () => {
 
       expect(mockService.identify).toHaveBeenCalledWith(
         expect.objectContaining({ correlationId: bodyCorrelationId }),
+        WORKSPACE_ID,
+      )
+    })
+  })
+
+  describe('POST /events/alias', () => {
+    const makeAlias = () => ({
+      userId: 'user_123',
+      anonymousId: 'anon_abc',
+      source: 'demo-store',
+      version: '1.0',
+    })
+
+    it('returns 202 with userId, anonymousId and created status', async () => {
+      mockService.alias.mockResolvedValue({ userId: 'user_123', anonymousId: 'anon_abc', status: 'created' })
+
+      const result = await controller.alias(WORKSPACE_ID, HEADER_CORRELATION_ID, makeAlias() as any)
+      expect(result).toEqual({ userId: 'user_123', anonymousId: 'anon_abc', status: 'created' })
+    })
+
+    it('returns exists status when alias already recorded', async () => {
+      mockService.alias.mockResolvedValue({ userId: 'user_123', anonymousId: 'anon_abc', status: 'exists' })
+
+      const result = await controller.alias(WORKSPACE_ID, HEADER_CORRELATION_ID, makeAlias() as any)
+      expect(result.status).toBe('exists')
+    })
+
+    it('uses header correlationId when body does not include one', async () => {
+      mockService.alias.mockResolvedValue({ userId: 'user_123', anonymousId: 'anon_abc', status: 'created' })
+
+      await controller.alias(WORKSPACE_ID, HEADER_CORRELATION_ID, makeAlias() as any)
+
+      expect(mockService.alias).toHaveBeenCalledWith(
+        expect.objectContaining({ correlationId: HEADER_CORRELATION_ID }),
         WORKSPACE_ID,
       )
     })

--- a/apps/ingestion/src/ingestion/ingestion.controller.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.controller.spec.ts
@@ -7,6 +7,7 @@ import { IngestionService } from './ingestion.service'
 const mockService = {
   ingest: vi.fn(),
   ingestBatch: vi.fn(),
+  identify: vi.fn(),
   findAll: vi.fn(),
   getThroughput: vi.fn(),
 }
@@ -84,6 +85,56 @@ describe('IngestionController', () => {
       expect(result.accepted).toBe(2)
       expect(result.duplicates).toBe(1)
       expect(result.results).toHaveLength(3)
+    })
+  })
+
+  describe('POST /events/identify', () => {
+    const makeIdentify = () => ({
+      userId: 'user_123',
+      source: 'demo-store',
+      version: '1.0',
+      traits: { name: 'Arif', email: 'arif@example.com' },
+    })
+
+    it('returns 202 with userId and created status for a new user', async () => {
+      mockService.identify.mockResolvedValue({ userId: 'user_123', status: 'created' })
+
+      const result = await controller.identify(WORKSPACE_ID, HEADER_CORRELATION_ID, makeIdentify() as any)
+      expect(result).toEqual({ userId: 'user_123', status: 'created' })
+    })
+
+    it('returns updated status when user traits already exist', async () => {
+      mockService.identify.mockResolvedValue({ userId: 'user_123', status: 'updated' })
+
+      const result = await controller.identify(WORKSPACE_ID, HEADER_CORRELATION_ID, makeIdentify() as any)
+      expect(result.status).toBe('updated')
+    })
+
+    it('uses header correlationId when body does not include one', async () => {
+      mockService.identify.mockResolvedValue({ userId: 'user_123', status: 'created' })
+
+      await controller.identify(WORKSPACE_ID, HEADER_CORRELATION_ID, makeIdentify() as any)
+
+      expect(mockService.identify).toHaveBeenCalledWith(
+        expect.objectContaining({ correlationId: HEADER_CORRELATION_ID }),
+        WORKSPACE_ID,
+      )
+    })
+
+    it('prefers body correlationId over header when both provided', async () => {
+      const bodyCorrelationId = randomUUID()
+      mockService.identify.mockResolvedValue({ userId: 'user_123', status: 'created' })
+
+      await controller.identify(
+        WORKSPACE_ID,
+        HEADER_CORRELATION_ID,
+        { ...makeIdentify(), correlationId: bodyCorrelationId } as any,
+      )
+
+      expect(mockService.identify).toHaveBeenCalledWith(
+        expect.objectContaining({ correlationId: bodyCorrelationId }),
+        WORKSPACE_ID,
+      )
     })
   })
 

--- a/apps/ingestion/src/ingestion/ingestion.controller.ts
+++ b/apps/ingestion/src/ingestion/ingestion.controller.ts
@@ -4,6 +4,7 @@ import { IngestionService } from './ingestion.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 import { IngestBatchDto } from './dto/ingest-batch.dto'
 import { IdentifyDto } from './dto/identify.dto'
+import { AliasDto } from './dto/alias.dto'
 import { QueryEventsDto } from './dto/query-events.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
@@ -49,6 +50,17 @@ export class IngestionController {
   ) {
     const correlationId = dto.correlationId ?? headerCorrelationId
     return this.ingestionService.identify({ ...dto, correlationId }, workspaceId)
+  }
+
+  @Post('alias')
+  @HttpCode(202)
+  async alias(
+    @WorkspaceId() workspaceId: string,
+    @Headers(CORRELATION_ID_HEADER) headerCorrelationId: string,
+    @Body() dto: AliasDto,
+  ) {
+    const correlationId = dto.correlationId ?? headerCorrelationId
+    return this.ingestionService.alias({ ...dto, correlationId }, workspaceId)
   }
 
   @Post('batch')

--- a/apps/ingestion/src/ingestion/ingestion.controller.ts
+++ b/apps/ingestion/src/ingestion/ingestion.controller.ts
@@ -3,6 +3,7 @@ import { WorkspaceId, CORRELATION_ID_HEADER } from '@flowmesh/nestjs-common'
 import { IngestionService } from './ingestion.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 import { IngestBatchDto } from './dto/ingest-batch.dto'
+import { IdentifyDto } from './dto/identify.dto'
 import { QueryEventsDto } from './dto/query-events.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
@@ -37,6 +38,17 @@ export class IngestionController {
     // x-correlation-id header that the API gateway always sets.
     const correlationId = dto.correlationId ?? headerCorrelationId
     return this.ingestionService.ingest({ ...dto, correlationId }, workspaceId)
+  }
+
+  @Post('identify')
+  @HttpCode(202)
+  async identify(
+    @WorkspaceId() workspaceId: string,
+    @Headers(CORRELATION_ID_HEADER) headerCorrelationId: string,
+    @Body() dto: IdentifyDto,
+  ) {
+    const correlationId = dto.correlationId ?? headerCorrelationId
+    return this.ingestionService.identify({ ...dto, correlationId }, workspaceId)
   }
 
   @Post('batch')

--- a/apps/ingestion/src/ingestion/ingestion.service.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.spec.ts
@@ -7,6 +7,7 @@ import { RabbitMQService } from '../rabbitmq/rabbitmq.service'
 import { RedisService } from '../redis/redis.service'
 import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
+import { IdentifyDto } from './dto/identify.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
 const mockLogger = {
@@ -30,7 +31,11 @@ const WORKSPACE_ID = randomUUID()
 
 describe('IngestionService', () => {
   let service: IngestionService
-  let prisma: { event: { create: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> }; $queryRaw: ReturnType<typeof vi.fn> }
+  let prisma: {
+    event: { create: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> }
+    userTrait: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> }
+    $queryRaw: ReturnType<typeof vi.fn>
+  }
   let rabbitmq: { publish: ReturnType<typeof vi.fn> }
   let redis: {
     isEventProcessed: ReturnType<typeof vi.fn>
@@ -41,6 +46,10 @@ describe('IngestionService', () => {
   beforeEach(() => {
     prisma = {
       event: { create: vi.fn().mockResolvedValue({}), count: vi.fn(), findMany: vi.fn() },
+      userTrait: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        upsert: vi.fn().mockResolvedValue({}),
+      },
       $queryRaw: vi.fn(),
     }
     rabbitmq = { publish: vi.fn().mockResolvedValue(undefined) }
@@ -153,6 +162,69 @@ describe('IngestionService', () => {
       const results = await service.ingestBatch(events, WORKSPACE_ID)
       const statuses = results.map((r) => r.status)
       expect(statuses).toEqual(['accepted', 'duplicate', 'accepted'])
+    })
+  })
+
+  describe('identify', () => {
+    const makeIdentify = (overrides: Partial<IdentifyDto> = {}): IdentifyDto & { correlationId: string } => ({
+      userId: 'user_123',
+      source: 'demo-store',
+      version: '1.0',
+      correlationId: randomUUID(),
+      traits: { name: 'Arif', email: 'arif@example.com' },
+      ...overrides,
+    })
+
+    it('returns created status when user does not exist yet', async () => {
+      prisma.userTrait.findUnique.mockResolvedValue(null)
+      const result = await service.identify(makeIdentify(), WORKSPACE_ID)
+      expect(result).toEqual({ userId: 'user_123', status: 'created' })
+    })
+
+    it('returns updated status when user traits already exist', async () => {
+      prisma.userTrait.findUnique.mockResolvedValue({ id: randomUUID() })
+      const result = await service.identify(makeIdentify(), WORKSPACE_ID)
+      expect(result).toEqual({ userId: 'user_123', status: 'updated' })
+    })
+
+    it('upserts user traits in the database', async () => {
+      const identify = makeIdentify()
+      await service.identify(identify, WORKSPACE_ID)
+      expect(prisma.userTrait.upsert).toHaveBeenCalledOnce()
+      const call = prisma.userTrait.upsert.mock.calls[0][0]
+      expect(call.where).toEqual({ workspaceId_userId: { workspaceId: WORKSPACE_ID, userId: 'user_123' } })
+      expect(call.create.traits).toEqual(identify.traits)
+      expect(call.update.traits).toEqual(identify.traits)
+    })
+
+    it('publishes user.identified event to RabbitMQ pipeline', async () => {
+      const identify = makeIdentify()
+      await service.identify(identify, WORKSPACE_ID)
+      expect(rabbitmq.publish).toHaveBeenCalledOnce()
+      const message = rabbitmq.publish.mock.calls[0][0]
+      expect(message.payload.event).toBe('user.identified')
+      expect(message.payload.userId).toBe('user_123')
+      expect(message.meta.workspaceId).toBe(WORKSPACE_ID)
+    })
+
+    it('publishes to live event feed with event name user.identified', async () => {
+      await service.identify(makeIdentify(), WORKSPACE_ID)
+      expect(pubsub.publishEvent).toHaveBeenCalledOnce()
+      const call = pubsub.publishEvent.mock.calls[0][0]
+      expect(call.eventName).toBe('user.identified')
+      expect(call.userId).toBe('user_123')
+    })
+
+    it('stores anonymousId when provided', async () => {
+      await service.identify(makeIdentify({ anonymousId: 'anon_xyz' }), WORKSPACE_ID)
+      const call = prisma.userTrait.upsert.mock.calls[0][0]
+      expect(call.create.anonymousId).toBe('anon_xyz')
+    })
+
+    it('stores empty traits object when traits are omitted', async () => {
+      await service.identify(makeIdentify({ traits: undefined }), WORKSPACE_ID)
+      const call = prisma.userTrait.upsert.mock.calls[0][0]
+      expect(call.create.traits).toEqual({})
     })
   })
 

--- a/apps/ingestion/src/ingestion/ingestion.service.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.spec.ts
@@ -8,6 +8,7 @@ import { RedisService } from '../redis/redis.service'
 import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 import { IdentifyDto } from './dto/identify.dto'
+import { AliasDto } from './dto/alias.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
 const mockLogger = {
@@ -34,6 +35,7 @@ describe('IngestionService', () => {
   let prisma: {
     event: { create: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> }
     userTrait: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> }
+    aliasMap: { findUnique: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> }
     $queryRaw: ReturnType<typeof vi.fn>
   }
   let rabbitmq: { publish: ReturnType<typeof vi.fn> }
@@ -49,6 +51,10 @@ describe('IngestionService', () => {
       userTrait: {
         findUnique: vi.fn().mockResolvedValue(null),
         upsert: vi.fn().mockResolvedValue({}),
+      },
+      aliasMap: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({}),
       },
       $queryRaw: vi.fn(),
     }
@@ -225,6 +231,64 @@ describe('IngestionService', () => {
       await service.identify(makeIdentify({ traits: undefined }), WORKSPACE_ID)
       const call = prisma.userTrait.upsert.mock.calls[0][0]
       expect(call.create.traits).toEqual({})
+    })
+  })
+
+  describe('alias', () => {
+    const makeAlias = (overrides: Partial<AliasDto> = {}): AliasDto & { correlationId: string } => ({
+      userId: 'user_123',
+      anonymousId: 'anon_abc',
+      source: 'demo-store',
+      version: '1.0',
+      correlationId: randomUUID(),
+      ...overrides,
+    })
+
+    it('returns created status when alias does not exist yet', async () => {
+      prisma.aliasMap.findUnique.mockResolvedValue(null)
+      const result = await service.alias(makeAlias(), WORKSPACE_ID)
+      expect(result).toEqual({ userId: 'user_123', anonymousId: 'anon_abc', status: 'created' })
+    })
+
+    it('returns exists status when alias already recorded', async () => {
+      prisma.aliasMap.findUnique.mockResolvedValue({ id: randomUUID() })
+      const result = await service.alias(makeAlias(), WORKSPACE_ID)
+      expect(result.status).toBe('exists')
+    })
+
+    it('does not create a duplicate alias record when alias already exists', async () => {
+      prisma.aliasMap.findUnique.mockResolvedValue({ id: randomUUID() })
+      await service.alias(makeAlias(), WORKSPACE_ID)
+      expect(prisma.aliasMap.create).not.toHaveBeenCalled()
+    })
+
+    it('persists the alias mapping to the database', async () => {
+      const alias = makeAlias()
+      await service.alias(alias, WORKSPACE_ID)
+      expect(prisma.aliasMap.create).toHaveBeenCalledOnce()
+      const call = prisma.aliasMap.create.mock.calls[0][0]
+      expect(call.data.workspaceId).toBe(WORKSPACE_ID)
+      expect(call.data.userId).toBe('user_123')
+      expect(call.data.anonymousId).toBe('anon_abc')
+    })
+
+    it('publishes user.aliased event to RabbitMQ pipeline', async () => {
+      const alias = makeAlias()
+      await service.alias(alias, WORKSPACE_ID)
+      expect(rabbitmq.publish).toHaveBeenCalledOnce()
+      const message = rabbitmq.publish.mock.calls[0][0]
+      expect(message.payload.event).toBe('user.aliased')
+      expect(message.payload.userId).toBe('user_123')
+      expect(message.payload.anonymousId).toBe('anon_abc')
+    })
+
+    it('publishes to live event feed with event name user.aliased', async () => {
+      await service.alias(makeAlias(), WORKSPACE_ID)
+      expect(pubsub.publishEvent).toHaveBeenCalledOnce()
+      const call = pubsub.publishEvent.mock.calls[0][0]
+      expect(call.eventName).toBe('user.aliased')
+      expect(call.userId).toBe('user_123')
+      expect(call.anonymousId).toBe('anon_abc')
     })
   })
 

--- a/apps/ingestion/src/ingestion/ingestion.service.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.ts
@@ -8,6 +8,7 @@ import { RedisService } from '../redis/redis.service'
 import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 import { IdentifyDto } from './dto/identify.dto'
+import { AliasDto } from './dto/alias.dto'
 import { QueryEventsDto } from './dto/query-events.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
@@ -30,6 +31,12 @@ export interface IngestResult {
 export interface IdentifyResult {
   userId: string
   status: 'created' | 'updated'
+}
+
+export interface AliasResult {
+  userId: string
+  anonymousId: string
+  status: 'created' | 'exists'
 }
 
 @Injectable()
@@ -155,6 +162,74 @@ export class IngestionService {
     this.logger.info({ eventId, correlationId: dto.correlationId, workspaceId, event: dto.event }, 'event accepted')
 
     return { eventId, status: 'accepted' }
+  }
+
+  async alias(
+    dto: AliasDto & { correlationId: string },
+    workspaceId: string,
+  ): Promise<AliasResult> {
+    const eventId = dto.eventId ?? randomUUID()
+    const timestamp = dto.timestamp ?? new Date().toISOString()
+
+    const existing = await this.prisma.aliasMap.findUnique({
+      where: { workspaceId_anonymousId: { workspaceId, anonymousId: dto.anonymousId } },
+      select: { id: true },
+    })
+
+    if (!existing) {
+      await this.prisma.aliasMap.create({
+        data: {
+          workspaceId,
+          anonymousId: dto.anonymousId,
+          userId: dto.userId,
+          source: dto.source,
+          version: dto.version,
+        },
+      })
+    }
+
+    // Publish so pipelines can react to alias events (e.g. welcome sequence after signup)
+    await this.rabbitmq.publish({
+      meta: {
+        messageId: randomUUID(),
+        correlationId: dto.correlationId,
+        timestamp: new Date().toISOString(),
+        source: 'ingestion',
+        version: '1.0',
+        workspaceId,
+      },
+      payload: {
+        eventId,
+        event: 'user.aliased',
+        source: dto.source,
+        version: dto.version,
+        userId: dto.userId,
+        anonymousId: dto.anonymousId,
+        properties: { anonymousId: dto.anonymousId },
+        context: {},
+        receivedAt: timestamp,
+      },
+    })
+
+    this.pubsub.publishEvent({
+      id: eventId,
+      eventId,
+      eventName: 'user.aliased',
+      source: dto.source,
+      userId: dto.userId,
+      anonymousId: dto.anonymousId,
+      correlationId: dto.correlationId,
+      properties: { anonymousId: dto.anonymousId },
+      receivedAt: timestamp,
+      workspaceId,
+    }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
+
+    this.logger.info(
+      { userId: dto.userId, anonymousId: dto.anonymousId, workspaceId, correlationId: dto.correlationId },
+      'alias created',
+    )
+
+    return { userId: dto.userId, anonymousId: dto.anonymousId, status: existing ? 'exists' : 'created' }
   }
 
   async ingestBatch(

--- a/apps/ingestion/src/ingestion/ingestion.service.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.ts
@@ -7,6 +7,7 @@ import { RabbitMQService } from '../rabbitmq/rabbitmq.service'
 import { RedisService } from '../redis/redis.service'
 import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
+import { IdentifyDto } from './dto/identify.dto'
 import { QueryEventsDto } from './dto/query-events.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
@@ -24,6 +25,11 @@ const RANGE_CONFIG = {
 export interface IngestResult {
   eventId: string
   status: 'accepted' | 'duplicate'
+}
+
+export interface IdentifyResult {
+  userId: string
+  status: 'created' | 'updated'
 }
 
 @Injectable()
@@ -156,6 +162,78 @@ export class IngestionService {
     workspaceId: string,
   ): Promise<IngestResult[]> {
     return Promise.all(events.map((event) => this.ingest(event, workspaceId)))
+  }
+
+  async identify(
+    dto: IdentifyDto & { correlationId: string },
+    workspaceId: string,
+  ): Promise<IdentifyResult> {
+    const eventId = dto.eventId ?? randomUUID()
+    const timestamp = dto.timestamp ?? new Date().toISOString()
+
+    const existing = await this.prisma.userTrait.findUnique({
+      where: { workspaceId_userId: { workspaceId, userId: dto.userId } },
+      select: { id: true },
+    })
+
+    await this.prisma.userTrait.upsert({
+      where: { workspaceId_userId: { workspaceId, userId: dto.userId } },
+      create: {
+        workspaceId,
+        userId: dto.userId,
+        anonymousId: dto.anonymousId ?? null,
+        traits: (dto.traits ?? {}) as object,
+        source: dto.source,
+        version: dto.version,
+      },
+      update: {
+        anonymousId: dto.anonymousId ?? null,
+        traits: (dto.traits ?? {}) as object,
+        source: dto.source,
+        version: dto.version,
+      },
+    })
+
+    // Publish to pipeline so identify calls can trigger rules (e.g. welcome Slack message)
+    await this.rabbitmq.publish({
+      meta: {
+        messageId: randomUUID(),
+        correlationId: dto.correlationId,
+        timestamp: new Date().toISOString(),
+        source: 'ingestion',
+        version: '1.0',
+        workspaceId,
+      },
+      payload: {
+        eventId,
+        event: 'user.identified',
+        source: dto.source,
+        version: dto.version,
+        userId: dto.userId,
+        anonymousId: dto.anonymousId,
+        properties: dto.traits ?? {},
+        context: dto.context ?? {},
+        receivedAt: timestamp,
+      },
+    })
+
+    // Publish to live feed so the dashboard shows identify calls
+    this.pubsub.publishEvent({
+      id: eventId,
+      eventId,
+      eventName: 'user.identified',
+      source: dto.source,
+      userId: dto.userId,
+      anonymousId: dto.anonymousId ?? null,
+      correlationId: dto.correlationId,
+      properties: dto.traits ?? {},
+      receivedAt: timestamp,
+      workspaceId,
+    }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
+
+    this.logger.info({ userId: dto.userId, workspaceId, correlationId: dto.correlationId }, 'user identified')
+
+    return { userId: dto.userId, status: existing ? 'updated' : 'created' }
   }
 
   async getThroughput(

--- a/docs/sdk-contract.md
+++ b/docs/sdk-contract.md
@@ -1,0 +1,256 @@
+# FlowMesh SDK Contract
+
+This document is the single source of truth for every FlowMesh client SDK. If you are building an SDK in a new language, implement everything here exactly. If you find a gap or an inconsistency, open an issue before changing anything — the contract must stay in sync across all SDKs.
+
+**Reference implementation:** `packages/sdk-node/` (`flowmesh-node` on npm)
+
+---
+
+## Methods
+
+Every SDK implements exactly these four methods. No SDK ships a subset. Future methods (`page`, `group`) are added to this document first and then implemented in all SDKs simultaneously.
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `track(input)` | `POST /ingest/events` | Send a named event |
+| `identify(input)` | `POST /ingest/events/identify` | Store traits for a known user |
+| `alias(input)` | `POST /ingest/events/alias` | Link an anonymous visitor to a known user |
+| `batch(inputs[])` | `POST /ingest/events/batch` | Send multiple track events in one call |
+
+---
+
+## Initialisation
+
+```
+new FlowMesh({
+  apiKey:     string   required    Your FlowMesh API key
+  host:       string   optional    Base URL of your FlowMesh instance. Default: http://localhost:3000
+  maxRetries: integer  optional    Delivery attempts per call. Default: 3
+  timeoutMs:  integer  optional    Per-request timeout in ms. Default: 10000
+})
+```
+
+- Throw on construction if `apiKey` is empty or missing
+- Strip trailing slash from `host`
+- Language-idiomatic naming allowed (`api_key` in Python) — semantics must be identical
+
+---
+
+## track
+
+Send a named event. Every meaningful user action or system event should be a `track` call.
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `event` | string | ✅ | Dot-notation event name, e.g. `order.placed`, `page.viewed` |
+| `source` | string | ✅ | Origin: `web`, `server`, `mobile`, `ios`, `android` |
+| `version` | string | ✅ | Schema version, e.g. `1.0` |
+| `userId` | string | one-of | Authenticated user ID. Required if `anonymousId` absent. |
+| `anonymousId` | string | one-of | Anonymous visitor ID. Required if `userId` absent. |
+| `sessionId` | string | optional | Session identifier |
+| `eventId` | UUID | optional | Provide to guarantee idempotency. Auto-generated if omitted. |
+| `timestamp` | ISO 8601 | optional | Event time. Server time used if omitted. |
+| `properties` | object | optional | Arbitrary key-value payload |
+| `context` | object | optional | Request context: IP, user agent, page URL |
+
+**Response:**
+
+```json
+{ "eventId": "uuid", "status": "accepted" }
+{ "eventId": "uuid", "status": "duplicate" }
+```
+
+`duplicate` means the `eventId` was already processed. The event was not re-inserted. Return this to the caller — do not raise an error.
+
+---
+
+## identify
+
+Store traits for a known user. Call this immediately after a user registers or logs in. Subsequent calls for the same `userId` update the stored traits (upsert).
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `userId` | string | ✅ | The known user ID |
+| `source` | string | ✅ | Origin of the identify call |
+| `version` | string | ✅ | Schema version |
+| `anonymousId` | string | optional | The anonymous ID the user had before logging in, if known |
+| `traits` | object | optional | User attributes: `name`, `email`, `plan`, `company`, etc. |
+| `eventId` | UUID | optional | Idempotency key |
+| `timestamp` | ISO 8601 | optional | |
+| `context` | object | optional | |
+
+**Response:**
+
+```json
+{ "userId": "user_123", "status": "created" }
+{ "userId": "user_123", "status": "updated" }
+```
+
+`created` on first call for a userId. `updated` on all subsequent calls.
+
+---
+
+## alias
+
+Link an anonymous visitor ID to a known userId. Call this once at login — after you have both the `anonymousId` (from localStorage or equivalent) and the `userId` (returned by your auth system). Idempotent: a second call with the same `anonymousId` returns `exists` without inserting a duplicate.
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `userId` | string | ✅ | The known user ID to link to |
+| `anonymousId` | string | ✅ | The anonymous visitor ID to be merged |
+| `source` | string | ✅ | |
+| `version` | string | ✅ | |
+| `eventId` | UUID | optional | |
+| `timestamp` | ISO 8601 | optional | |
+
+**Response:**
+
+```json
+{ "userId": "user_123", "anonymousId": "anon_abc", "status": "created" }
+{ "userId": "user_123", "anonymousId": "anon_abc", "status": "exists" }
+```
+
+---
+
+## batch
+
+Send multiple track events in a single HTTP request. Reduces connection overhead for server-side event generation. Each element in the array follows the exact same shape as a `track` call.
+
+**Input:**
+
+```json
+{
+  "events": [
+    { "event": "page.viewed", "source": "web", "version": "1.0", "userId": "user_123", "properties": {} },
+    { "event": "product.viewed", "source": "web", "version": "1.0", "userId": "user_123", "properties": {} }
+  ]
+}
+```
+
+- Minimum 1 event. Throw if array is empty.
+- Maximum 100 events per call. Throw if array exceeds 100.
+- Each event is validated individually. If event at index 2 has a missing `source`, throw: `"batch[2]: source is required"`.
+
+**Response:**
+
+```json
+{
+  "accepted": 2,
+  "duplicates": 0,
+  "results": [
+    { "eventId": "uuid-1", "status": "accepted" },
+    { "eventId": "uuid-2", "status": "accepted" }
+  ]
+}
+```
+
+---
+
+## HTTP Contract
+
+Every request must send:
+
+```
+POST {host}{path}
+Content-Type: application/json
+x-api-key: {apiKey}
+```
+
+The API key goes in the `x-api-key` header. Never in the URL, never in the request body.
+
+All endpoints return `202 Accepted` on success. Treat any `2xx` as success.
+
+---
+
+## Retry and Error Behaviour
+
+| Response | Action |
+|---|---|
+| `2xx` | Return result. Do not retry. |
+| `429 Too Many Requests` | Retry with exponential backoff. Honour `Retry-After` header if present. |
+| `5xx Server Error` | Retry with exponential backoff up to `maxRetries`. |
+| `4xx` (except 429) | Throw immediately. No retry. These are caller errors. |
+| Timeout | Treat as transient. Retry up to `maxRetries`. |
+| Network error | Retry up to `maxRetries`. |
+
+**Backoff formula:** `delay = 500ms * 2^(attempt - 1)` capped at 30 seconds, with ±20% random jitter.
+
+After all retries are exhausted, throw a descriptive error that includes the HTTP status or error message of the last attempt.
+
+---
+
+## Client-Side Validation
+
+Validate required fields before making any network call. Throw immediately on missing fields — do not send a request that will return `400`.
+
+| Method | Required fields |
+|---|---|
+| `track` | `event`, `source`, `version`, `userId` or `anonymousId` |
+| `identify` | `userId`, `source`, `version` |
+| `alias` | `userId`, `anonymousId`, `source`, `version` |
+| `batch` | array must not be empty; each element validated as track |
+
+Error message must name the field: `"FlowMesh: source is required"` not `"invalid input"`.
+
+For batch, prefix with the index: `"FlowMesh: batch[2]: event is required"`.
+
+---
+
+## Test Coverage
+
+Every SDK must have tests covering the following cases for each method:
+
+### Constructor
+- Empty `apiKey` → throws on construction, no network call made
+- Trailing slash on `host` is stripped
+
+### Each method (track, identify, alias)
+- Happy path → returns correct response shape
+- Posts to the correct endpoint
+- Sends `x-api-key` header
+- Missing required field → throws, no network call made
+- `5xx` → retries, succeeds on second attempt
+- Persistent `5xx` → throws after `maxRetries` attempts
+- `4xx` (400, 401) → throws immediately, exactly 1 network call made
+
+### batch additionally
+- Empty array → throws before network call
+- Over 100 elements → throws before network call
+- Validation error at index N → throws naming the index
+
+Coverage threshold: 80% statements, branches, and functions.
+
+---
+
+## Planned Methods (not yet implemented)
+
+These will be added to all SDKs simultaneously when the backend endpoints ship:
+
+### page (post-launch v0.2)
+```
+page(input)  →  POST /ingest/events/page
+```
+First-class page view. Fields: `name` (page title, required), `url` (optional), plus all track fields except `event` (which is set to `page.viewed` automatically).
+
+### group (post-launch v0.2)
+```
+group(input)  →  POST /ingest/events/group
+```
+Associate a userId with an organisation or account. Fields: `userId` (required), `groupId` (required), `traits` (optional — company name, plan, size, etc.).
+
+---
+
+## Adding a New SDK
+
+1. Read this document fully before writing any code.
+2. Use `packages/sdk-node/` as the reference implementation.
+3. Method names, input field names, response field names, and error message format must match exactly (modulo language conventions for casing).
+4. All test cases from the Test Coverage section must pass before the SDK is published.
+5. Write a `README.md` covering: install, initialisation, one example per method, error handling, link to this document.
+6. Open a PR to add the SDK to the monorepo root `README.md` SDKs section.

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowmesh-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Official Node.js SDK for FlowMesh — self-hostable event pipeline platform",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk-node/src/client.spec.ts
+++ b/packages/sdk-node/src/client.spec.ts
@@ -109,6 +109,83 @@ describe('FlowMesh', () => {
     })
   })
 
+  describe('identify', () => {
+    const VALID_IDENTIFY = {
+      userId: 'user_123',
+      source: 'demo-store',
+      version: '1.0',
+      traits: { name: 'Arif', email: 'arif@example.com' },
+    }
+
+    beforeEach(() => {
+      vi.stubGlobal('fetch', makeFetch(202, { userId: 'user_123', status: 'created' }))
+    })
+
+    it('posts to /ingest/events/identify with api key header', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test', host: 'http://localhost:3000' })
+      const result = await client.identify(VALID_IDENTIFY)
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:3000/ingest/events/identify',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'x-api-key': 'fm_test' }),
+        }),
+      )
+      expect(result).toEqual({ userId: 'user_123', status: 'created' })
+    })
+
+    it('returns updated status when user already exists', async () => {
+      vi.stubGlobal('fetch', makeFetch(202, { userId: 'user_123', status: 'updated' }))
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      const result = await client.identify(VALID_IDENTIFY)
+      expect(result.status).toBe('updated')
+    })
+
+    it('throws when userId is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.identify({ ...VALID_IDENTIFY, userId: '' })).rejects.toThrow('userId is required')
+    })
+
+    it('throws when source is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.identify({ ...VALID_IDENTIFY, source: '' })).rejects.toThrow('source is required')
+    })
+
+    it('throws when version is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.identify({ ...VALID_IDENTIFY, version: '' })).rejects.toThrow('version is required')
+    })
+
+    it('works with no traits provided', async () => {
+      vi.stubGlobal('fetch', makeFetch(202, { userId: 'user_123', status: 'created' }))
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      const result = await client.identify({ userId: 'user_123', source: 'app', version: '1.0' })
+      expect(result.status).toBe('created')
+    })
+
+    it('retries on 500 and succeeds', async () => {
+      let calls = 0
+      vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+        calls++
+        if (calls < 2) return Promise.resolve({ status: 500, json: () => Promise.resolve({}) })
+        return Promise.resolve({ status: 202, json: () => Promise.resolve({ userId: 'user_123', status: 'created' }) })
+      }))
+
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      const result = await client.identify(VALID_IDENTIFY)
+      expect(calls).toBe(2)
+      expect(result.userId).toBe('user_123')
+    })
+
+    it('throws immediately on 401 without retrying', async () => {
+      vi.stubGlobal('fetch', makeFetch(401, {}))
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      await expect(client.identify(VALID_IDENTIFY)).rejects.toThrow('status 401')
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('batch', () => {
     beforeEach(() => {
       vi.stubGlobal('fetch', makeFetch(202, { accepted: 2, duplicates: 0, results: [] }))

--- a/packages/sdk-node/src/client.spec.ts
+++ b/packages/sdk-node/src/client.spec.ts
@@ -186,6 +186,76 @@ describe('FlowMesh', () => {
     })
   })
 
+  describe('alias', () => {
+    const VALID_ALIAS = {
+      userId: 'user_123',
+      anonymousId: 'anon_abc',
+      source: 'demo-store',
+      version: '1.0',
+    }
+
+    beforeEach(() => {
+      vi.stubGlobal('fetch', makeFetch(202, { userId: 'user_123', anonymousId: 'anon_abc', status: 'created' }))
+    })
+
+    it('posts to /ingest/events/alias with api key header', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test', host: 'http://localhost:3000' })
+      const result = await client.alias(VALID_ALIAS)
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:3000/ingest/events/alias',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'x-api-key': 'fm_test' }),
+        }),
+      )
+      expect(result).toEqual({ userId: 'user_123', anonymousId: 'anon_abc', status: 'created' })
+    })
+
+    it('returns exists status when alias already recorded', async () => {
+      vi.stubGlobal('fetch', makeFetch(202, { userId: 'user_123', anonymousId: 'anon_abc', status: 'exists' }))
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      const result = await client.alias(VALID_ALIAS)
+      expect(result.status).toBe('exists')
+    })
+
+    it('throws when userId is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.alias({ ...VALID_ALIAS, userId: '' })).rejects.toThrow('userId is required')
+    })
+
+    it('throws when anonymousId is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.alias({ ...VALID_ALIAS, anonymousId: '' })).rejects.toThrow('anonymousId is required')
+    })
+
+    it('throws when source is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.alias({ ...VALID_ALIAS, source: '' })).rejects.toThrow('source is required')
+    })
+
+    it('retries on 500 and succeeds', async () => {
+      let calls = 0
+      vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+        calls++
+        if (calls < 2) return Promise.resolve({ status: 500, json: () => Promise.resolve({}) })
+        return Promise.resolve({ status: 202, json: () => Promise.resolve({ userId: 'user_123', anonymousId: 'anon_abc', status: 'created' }) })
+      }))
+
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      const result = await client.alias(VALID_ALIAS)
+      expect(calls).toBe(2)
+      expect(result.status).toBe('created')
+    })
+
+    it('throws immediately on 401 without retrying', async () => {
+      vi.stubGlobal('fetch', makeFetch(401, {}))
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      await expect(client.alias(VALID_ALIAS)).rejects.toThrow('status 401')
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('batch', () => {
     beforeEach(() => {
       vi.stubGlobal('fetch', makeFetch(202, { accepted: 2, duplicates: 0, results: [] }))

--- a/packages/sdk-node/src/client.ts
+++ b/packages/sdk-node/src/client.ts
@@ -1,5 +1,5 @@
 import { withRetry } from './retry.js'
-import type { FlowMeshOptions, TrackInput, TrackResult, BatchResult } from './types.js'
+import type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult } from './types.js'
 
 const DEFAULT_HOST = 'http://localhost:3000'
 const DEFAULT_MAX_RETRIES = 3
@@ -25,6 +25,18 @@ export class FlowMesh {
     return withRetry(async () => {
       const res = await this.post('/ingest/events', input)
       const body = await res.json() as TrackResult
+      return { status: res.status, body }
+    }, this.maxRetries)
+  }
+
+  async identify(input: IdentifyInput): Promise<IdentifyResult> {
+    if (!input.userId) throw new Error('FlowMesh: userId is required for identify')
+    if (!input.source) throw new Error('FlowMesh: source is required')
+    if (!input.version) throw new Error('FlowMesh: version is required')
+
+    return withRetry(async () => {
+      const res = await this.post('/ingest/events/identify', input)
+      const body = await res.json() as IdentifyResult
       return { status: res.status, body }
     }, this.maxRetries)
   }

--- a/packages/sdk-node/src/client.ts
+++ b/packages/sdk-node/src/client.ts
@@ -1,5 +1,5 @@
 import { withRetry } from './retry.js'
-import type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult } from './types.js'
+import type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, AliasInput, AliasResult } from './types.js'
 
 const DEFAULT_HOST = 'http://localhost:3000'
 const DEFAULT_MAX_RETRIES = 3
@@ -37,6 +37,19 @@ export class FlowMesh {
     return withRetry(async () => {
       const res = await this.post('/ingest/events/identify', input)
       const body = await res.json() as IdentifyResult
+      return { status: res.status, body }
+    }, this.maxRetries)
+  }
+
+  async alias(input: AliasInput): Promise<AliasResult> {
+    if (!input.userId) throw new Error('FlowMesh: userId is required for alias')
+    if (!input.anonymousId) throw new Error('FlowMesh: anonymousId is required for alias')
+    if (!input.source) throw new Error('FlowMesh: source is required')
+    if (!input.version) throw new Error('FlowMesh: version is required')
+
+    return withRetry(async () => {
+      const res = await this.post('/ingest/events/alias', input)
+      const body = await res.json() as AliasResult
       return { status: res.status, body }
     }, this.maxRetries)
   }

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -1,2 +1,2 @@
 export { FlowMesh } from './client.js'
-export type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, FlowMeshError } from './types.js'
+export type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, FlowMeshError } from './types.js'

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -1,2 +1,2 @@
 export { FlowMesh } from './client.js'
-export type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, FlowMeshError } from './types.js'
+export type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, AliasInput, AliasResult, FlowMeshError } from './types.js'

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -48,6 +48,21 @@ export interface IdentifyResult {
   status: 'created' | 'updated'
 }
 
+export interface AliasInput {
+  userId: string
+  anonymousId: string
+  source: string
+  version: string
+  eventId?: string
+  timestamp?: string
+}
+
+export interface AliasResult {
+  userId: string
+  anonymousId: string
+  status: 'created' | 'exists'
+}
+
 export interface FlowMeshError extends Error {
   status?: number
 }

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -32,6 +32,22 @@ export interface BatchResult {
   results: TrackResult[]
 }
 
+export interface IdentifyInput {
+  userId: string
+  anonymousId?: string
+  source: string
+  version: string
+  traits?: Record<string, unknown>
+  eventId?: string
+  timestamp?: string
+  context?: Record<string, unknown>
+}
+
+export interface IdentifyResult {
+  userId: string
+  status: 'created' | 'updated'
+}
+
 export interface FlowMeshError extends Error {
   status?: number
 }


### PR DESCRIPTION
## Summary

- Adds `POST /ingest/events/identify` — upserts `user_traits` table, publishes `user.identified` to pipeline and live feed
- Adds `POST /ingest/events/alias` — idempotent write to `alias_map` (anonymous_id → user_id), publishes `user.aliased`
- Adds `client.identify()` and `client.alias()` to `flowmesh-node` SDK with full validation and retry behaviour per the SDK contract
- Bumps `flowmesh-node` to v0.2.0
- Adds `docs/sdk-contract.md` — public contributor spec for all current and future SDKs
- Updates `README.md` ingestion endpoints table and features table
- Updates `CONTRIBUTING.md` status table and commit scopes

## New database tables (ingestion schema)

- `user_traits` — unique on (workspace_id, user_id), upserted on every identify call
- `alias_map` — unique on (workspace_id, anonymous_id), idempotent insert

## Test coverage

- `ingestion.service.spec.ts` — 29 tests (up from 14), includes identify and alias happy paths, idempotency, pipeline publish, and error cases
- `ingestion.controller.spec.ts` — 13 tests (up from 6)
- `packages/sdk-node/src/client.spec.ts` — 30 tests (up from 15), covers identify and alias validation, retries, 4xx fast-fail, header assertion
- All 293 unit tests pass, typecheck clean

## Test plan

- [ ] `make test` passes (293 tests)
- [ ] `pnpm typecheck` clean
- [ ] `POST /ingest/events/identify` with valid payload → 202, `user_traits` row created
- [ ] Second identify for same userId → 202, row updated, status `updated`
- [ ] `POST /ingest/events/alias` with valid payload → 202, `alias_map` row created
- [ ] Second alias with same anonymousId → 202, status `exists`, no duplicate row
- [ ] `client.identify()` missing `userId` → throws before network call
- [ ] `client.alias()` missing `anonymousId` → throws before network call