### PR TITLE
feat(ingestion): identity stitching, user profile, events page filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Clone the repo, run one command, and have a working event pipeline running local
 | Event ingestion API (REST + SDK) | ✅ Available |
 | `identify()` — store user traits, link userId to profile | ✅ Available |
 | `alias()` — link anonymous visitor to known user at login | ✅ Available |
+| `page()` — record page views, auto-sets event to `page.viewed` | ✅ Available |
+| `group()` — associate a user with an organisation or account | ✅ Available |
 | Schema validation and auto-generated correlation ID tracing | ✅ Available |
 | Idempotent event deduplication | ✅ Available |
 | RabbitMQ-backed event queue | ✅ Available |
@@ -218,14 +220,16 @@ curl -X POST http://localhost:3000/ingest/events/batch \
 
 ## Event Schema
 
-FlowMesh exposes three ingestion endpoints:
+FlowMesh exposes six ingestion endpoints:
 
 | Endpoint | Purpose |
 |---|---|
-| `POST /ingest/events` | Track a named event — page views, clicks, orders, anything |
+| `POST /ingest/events` | Track a named event — clicks, orders, signups, anything |
 | `POST /ingest/events/identify` | Store traits for a known user (`name`, `email`, `plan`, etc.) |
 | `POST /ingest/events/alias` | Link an anonymous visitor ID to a known userId at login time |
-| `POST /ingest/events/batch` | Send up to 100 events in a single request |
+| `POST /ingest/events/page` | Record a page view — auto-sets event to `page.viewed` |
+| `POST /ingest/events/group` | Associate a user with an organisation or account |
+| `POST /ingest/events/batch` | Send up to 100 track events in a single request |
 
 Every event sent to FlowMesh follows this structure:
 

--- a/apps/dashboard/src/pages/events/EventsPage.tsx
+++ b/apps/dashboard/src/pages/events/EventsPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Search, ChevronDown, ChevronRight, Zap, Wifi, WifiOff } from 'lucide-react'
+import { Search, ChevronDown, ChevronRight, Zap, Wifi, WifiOff, User, X, Filter, UserCircle } from 'lucide-react'
 import api from '../../lib/api'
 import { useEventStream, type LiveEvent } from '../../hooks/useEventStream'
+import { UserProfileDrawer } from './UserProfileDrawer'
 
 interface Event {
   id: string
@@ -35,9 +36,27 @@ function formatRelative(iso: string): string {
   return new Date(iso).toLocaleDateString()
 }
 
-function EventRow({ event, isLive }: { event: Event | LiveEvent; isLive?: boolean }) {
+function EventRow({
+  event,
+  isLive,
+  onUserClick,
+  onUserProfile,
+  activeUserFilterType,
+}: {
+  event: Event | LiveEvent
+  isLive?: boolean
+  onUserClick: (id: string, type: 'userId' | 'anonymousId') => void
+  onUserProfile: (userId: string) => void
+  activeUserFilterType?: 'userId' | 'anonymousId'
+}) {
   const [expanded, setExpanded] = useState(false)
   const hasProperties = event.properties && Object.keys(event.properties).length > 0
+
+  // When filtering by anonymousId and the event has both IDs, prefer showing the anonymousId
+  // so the User column stays consistent with what the filter matched on.
+  const preferAnon = activeUserFilterType === 'anonymousId' && !!event.anonymousId
+  const userDisplay = preferAnon ? event.anonymousId : (event.userId ?? event.anonymousId)
+  const userType: 'userId' | 'anonymousId' = preferAnon ? 'anonymousId' : (event.userId ? 'userId' : 'anonymousId')
 
   return (
     <>
@@ -62,8 +81,35 @@ function EventRow({ event, isLive }: { event: Event | LiveEvent; isLive?: boolea
           </span>
         </td>
         <td className="px-4 py-3 text-sm text-gray-600">{event.source}</td>
-        <td className="px-4 py-3 text-sm text-gray-500">
-          {event.userId ?? event.anonymousId ?? '—'}
+        <td className="px-4 py-3">
+          {userDisplay ? (
+            <div className="flex items-center gap-1 group/user">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onUserClick(userDisplay, userType)
+                }}
+                title={`Filter by ${userType === 'userId' ? 'user' : 'anonymous'} ID`}
+                className="text-xs font-mono text-indigo-600 hover:underline hover:text-indigo-800 transition-colors max-w-[140px] truncate block text-left"
+              >
+                {userDisplay}
+              </button>
+              {userType === 'userId' && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onUserProfile(userDisplay)
+                  }}
+                  title="View user profile"
+                  className="opacity-0 group-hover/user:opacity-100 text-gray-400 hover:text-indigo-600 transition-all shrink-0"
+                >
+                  <UserCircle className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </div>
+          ) : (
+            <span className="text-gray-400 text-sm">—</span>
+          )}
         </td>
         <td className="px-4 py-3 text-xs font-mono text-gray-400 max-w-[160px] truncate">
           {event.correlationId}
@@ -89,7 +135,16 @@ function EventRow({ event, isLive }: { event: Event | LiveEvent; isLive?: boolea
 export default function EventsPage() {
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [userFilter, setUserFilter] = useState('')
+  const [userFilterType, setUserFilterType] = useState<'userId' | 'anonymousId'>('userId')
+  const [debouncedUser, setDebouncedUser] = useState('')
+  const [debouncedUserType, setDebouncedUserType] = useState<'userId' | 'anonymousId'>('userId')
+  const [eventFilter, setEventFilter] = useState('')
+  const [debouncedEvent, setDebouncedEvent] = useState('')
+  const [sourceFilter, setSourceFilter] = useState('')
+  const [debouncedSource, setDebouncedSource] = useState('')
   const [offset, setOffset] = useState(0)
+  const [profileUserId, setProfileUserId] = useState<string | null>(null)
   const limit = 50
 
   const { liveEvents, status } = useEventStream()
@@ -103,13 +158,70 @@ export default function EventsPage() {
     }, 400)
   }
 
+  function handleUserInput(value: string) {
+    setUserFilter(value)
+    const type = value.startsWith('anon_') ? 'anonymousId' : 'userId'
+    setUserFilterType(type)
+    clearTimeout((handleUserInput as unknown as { timer?: ReturnType<typeof setTimeout> }).timer)
+    ;(handleUserInput as unknown as { timer?: ReturnType<typeof setTimeout> }).timer = setTimeout(() => {
+      setDebouncedUser(value)
+      setDebouncedUserType(type)
+      setOffset(0)
+    }, 400)
+  }
+
+  function applyUserClick(id: string, type: 'userId' | 'anonymousId') {
+    setUserFilter(id)
+    setUserFilterType(type)
+    setDebouncedUser(id)
+    setDebouncedUserType(type)
+    setOffset(0)
+  }
+
+  function clearUserFilter() {
+    setUserFilter('')
+    setUserFilterType('userId')
+    setDebouncedUser('')
+    setDebouncedUserType('userId')
+    setOffset(0)
+  }
+
+  function handleEventFilter(value: string) {
+    setEventFilter(value)
+    clearTimeout((handleEventFilter as unknown as { timer?: ReturnType<typeof setTimeout> }).timer)
+    ;(handleEventFilter as unknown as { timer?: ReturnType<typeof setTimeout> }).timer = setTimeout(() => {
+      setDebouncedEvent(value)
+      setOffset(0)
+    }, 400)
+  }
+
+  function handleSourceFilter(value: string) {
+    setSourceFilter(value)
+    clearTimeout((handleSourceFilter as unknown as { timer?: ReturnType<typeof setTimeout> }).timer)
+    ;(handleSourceFilter as unknown as { timer?: ReturnType<typeof setTimeout> }).timer = setTimeout(() => {
+      setDebouncedSource(value)
+      setOffset(0)
+    }, 400)
+  }
+
+  function clearAllFilters() {
+    setSearch(''); setDebouncedSearch('')
+    setUserFilter(''); setUserFilterType('userId'); setDebouncedUser(''); setDebouncedUserType('userId')
+    setEventFilter(''); setDebouncedEvent('')
+    setSourceFilter(''); setDebouncedSource('')
+    setOffset(0)
+  }
+
   const { data, isLoading, error } = useQuery<EventsResponse>({
-    queryKey: ['events', debouncedSearch, offset],
+    queryKey: ['events', debouncedSearch, debouncedUser, debouncedUserType, debouncedEvent, debouncedSource, offset],
     queryFn: () => {
       const params = new URLSearchParams()
       params.set('limit', String(limit))
       params.set('offset', String(offset))
       if (debouncedSearch) params.set('search', debouncedSearch)
+      if (debouncedUser) params.set(debouncedUserType, debouncedUser)
+      if (debouncedEvent) params.set('event', debouncedEvent)
+      if (debouncedSource) params.set('source', debouncedSource)
       return api.get<EventsResponse>(`/events?${params}`).then((r) => r.data)
     },
   })
@@ -119,9 +231,9 @@ export default function EventsPage() {
   const pages = Math.ceil(total / limit)
   const currentPage = Math.floor(offset / limit) + 1
 
-  // When searching or paginating, show only REST results.
-  // On the first page with no search, prepend live events (deduped against REST results).
-  const isLivePage = !debouncedSearch && offset === 0
+  const hasFilter = !!(debouncedSearch || debouncedUser || debouncedEvent || debouncedSource)
+  const activeFilterCount = [debouncedSearch, debouncedUser, debouncedEvent, debouncedSource].filter(Boolean).length
+  const isLivePage = !hasFilter && offset === 0
   const storedIds = new Set(storedEvents.map((e) => e.eventId))
   const newLiveEvents = isLivePage ? liveEvents.filter((e) => !storedIds.has(e.eventId)) : []
   const displayEvents: (Event | LiveEvent)[] = [...newLiveEvents, ...storedEvents]
@@ -153,6 +265,7 @@ export default function EventsPage() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden">
+        {/* Search bar */}
         <div className="px-4 py-3 border-b border-gray-100 flex items-center gap-3">
           <Search className="w-4 h-4 text-gray-400 shrink-0" />
           <input
@@ -169,6 +282,77 @@ export default function EventsPage() {
           )}
         </div>
 
+        {/* Filter bar */}
+        <div className="px-4 py-2.5 border-b border-gray-100 bg-gray-50/60 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <div className="flex items-center gap-2 min-w-[200px] flex-1">
+            <User className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+            <input
+              type="text"
+              placeholder="User ID or anonymous ID…"
+              value={userFilter}
+              onChange={(e) => handleUserInput(e.target.value)}
+              className="flex-1 text-xs outline-none placeholder-gray-400 bg-transparent min-w-0"
+            />
+            {userFilter && (
+              <button onClick={clearUserFilter} aria-label="Clear user filter" className="text-gray-400 hover:text-gray-600 transition-colors">
+                <X className="w-3 h-3" />
+              </button>
+            )}
+            {debouncedUser && (
+              <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full font-medium whitespace-nowrap">
+                {debouncedUserType === 'anonymousId' ? 'anon' : 'user'}
+              </span>
+            )}
+          </div>
+
+          <div className="w-px h-4 bg-gray-200 hidden sm:block" />
+
+          <div className="flex items-center gap-2 min-w-[160px] flex-1">
+            <Filter className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+            <input
+              type="text"
+              placeholder="Event name…"
+              value={eventFilter}
+              onChange={(e) => handleEventFilter(e.target.value)}
+              className="flex-1 text-xs outline-none placeholder-gray-400 bg-transparent min-w-0 font-mono"
+            />
+            {eventFilter && (
+              <button onClick={() => { setEventFilter(''); setDebouncedEvent(''); setOffset(0) }} aria-label="Clear event filter" className="text-gray-400 hover:text-gray-600 transition-colors">
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </div>
+
+          <div className="w-px h-4 bg-gray-200 hidden sm:block" />
+
+          <div className="flex items-center gap-2 min-w-[120px] flex-1">
+            <input
+              type="text"
+              placeholder="Source…"
+              value={sourceFilter}
+              onChange={(e) => handleSourceFilter(e.target.value)}
+              className="flex-1 text-xs outline-none placeholder-gray-400 bg-transparent min-w-0"
+            />
+            {sourceFilter && (
+              <button onClick={() => { setSourceFilter(''); setDebouncedSource(''); setOffset(0) }} aria-label="Clear source filter" className="text-gray-400 hover:text-gray-600 transition-colors">
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </div>
+
+          {activeFilterCount > 1 && (
+            <>
+              <div className="w-px h-4 bg-gray-200 hidden sm:block" />
+              <button
+                onClick={clearAllFilters}
+                className="text-xs text-gray-400 hover:text-gray-600 whitespace-nowrap transition-colors"
+              >
+                Clear all
+              </button>
+            </>
+          )}
+        </div>
+
         {isLoading ? (
           <div className="py-16 text-center text-sm text-gray-400">Loading events…</div>
         ) : error ? (
@@ -182,8 +366,8 @@ export default function EventsPage() {
             </div>
             <p className="text-sm font-medium text-gray-700 mb-1">No events yet</p>
             <p className="text-xs text-gray-400">
-              {debouncedSearch
-                ? 'No events match your search.'
+              {hasFilter
+                ? 'No events match your filters.'
                 : 'Send your first event via POST /ingest/events to see it here.'}
             </p>
           </div>
@@ -206,6 +390,9 @@ export default function EventsPage() {
                     key={event.eventId}
                     event={event}
                     isLive={newLiveEvents.some((e) => e.eventId === event.eventId)}
+                    onUserClick={applyUserClick}
+                    onUserProfile={setProfileUserId}
+                    activeUserFilterType={debouncedUser ? debouncedUserType : undefined}
                   />
                 ))}
               </tbody>
@@ -237,6 +424,17 @@ export default function EventsPage() {
           </div>
         )}
       </div>
+
+      {profileUserId && (
+        <UserProfileDrawer
+          userId={profileUserId}
+          onClose={() => setProfileUserId(null)}
+          onFilterEvents={(id, type) => {
+            applyUserClick(id, type)
+            setProfileUserId(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/pages/events/UserProfileDrawer.tsx
+++ b/apps/dashboard/src/pages/events/UserProfileDrawer.tsx
@@ -1,0 +1,213 @@
+import { useQuery } from '@tanstack/react-query'
+import { X, User, Link2, Users, Calendar, Activity, ChevronRight } from 'lucide-react'
+import api from '../../lib/api'
+
+interface UserProfile {
+  userId: string
+  traits: Record<string, unknown>
+  anonymousIds: { anonymousId: string; linkedAt: string }[]
+  groups: { groupId: string; traits: Record<string, unknown>; joinedAt: string }[]
+  eventCount: number
+  firstSeen: string | null
+  lastSeen: string | null
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+function Avatar({ userId }: { userId: string }) {
+  const initials = userId.replace(/[^a-zA-Z]/g, '').slice(0, 2).toUpperCase() || userId.slice(0, 2).toUpperCase()
+  return (
+    <div className="w-12 h-12 rounded-full bg-indigo-100 flex items-center justify-center shrink-0">
+      <span className="text-indigo-700 font-bold text-sm">{initials}</span>
+    </div>
+  )
+}
+
+function Section({ icon, title, children }: { icon: React.ReactNode; title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-gray-400">{icon}</span>
+        <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">{title}</span>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export function UserProfileDrawer({
+  userId,
+  onClose,
+  onFilterEvents,
+}: {
+  userId: string
+  onClose: () => void
+  onFilterEvents: (id: string, type: 'userId' | 'anonymousId') => void
+}) {
+  const { data, isLoading, error } = useQuery<UserProfile>({
+    queryKey: ['user-profile', userId],
+    queryFn: () => api.get<UserProfile>(`/events/users/${encodeURIComponent(userId)}`).then((r) => r.data),
+    enabled: !!userId,
+  })
+
+  const traitEntries = data ? Object.entries(data.traits) : []
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/20 z-40"
+        onClick={onClose}
+      />
+
+      {/* Drawer */}
+      <div className="fixed right-0 top-0 h-full w-96 bg-white border-l border-gray-200 shadow-xl z-50 flex flex-col">
+        {/* Header */}
+        <div className="px-5 py-4 border-b border-gray-100 flex items-start gap-3">
+          <Avatar userId={userId} />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-gray-400 mb-0.5">User ID</p>
+            <p className="text-sm font-mono text-gray-900 break-all leading-snug">{userId}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors shrink-0 mt-0.5"
+            aria-label="Close profile"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          {isLoading && (
+            <div className="py-12 text-center text-sm text-gray-400">Loading profile…</div>
+          )}
+          {error && (
+            <div className="py-12 text-center text-sm text-red-500">Failed to load profile.</div>
+          )}
+          {data && (
+            <>
+              {/* Event stats */}
+              <div className="grid grid-cols-3 gap-2">
+                <div className="bg-indigo-50 rounded-lg px-3 py-2.5 text-center">
+                  <p className="text-lg font-bold text-indigo-700">{data.eventCount.toLocaleString()}</p>
+                  <p className="text-xs text-indigo-500 mt-0.5">Events</p>
+                </div>
+                <div className="bg-gray-50 rounded-lg px-3 py-2.5 text-center col-span-2">
+                  <p className="text-xs text-gray-500 mb-1">First seen</p>
+                  <p className="text-xs font-medium text-gray-700">{formatDate(data.firstSeen)}</p>
+                </div>
+              </div>
+
+              {/* Traits */}
+              <Section icon={<User className="w-3.5 h-3.5" />} title="Traits">
+                {traitEntries.length === 0 ? (
+                  <p className="text-xs text-gray-400 italic">No traits recorded</p>
+                ) : (
+                  <div className="rounded-lg border border-gray-100 overflow-hidden">
+                    {traitEntries.map(([key, value], i) => (
+                      <div
+                        key={key}
+                        className={`flex items-start justify-between gap-3 px-3 py-2 text-xs ${i > 0 ? 'border-t border-gray-50' : ''}`}
+                      >
+                        <span className="text-gray-500 shrink-0">{key}</span>
+                        <span className="font-medium text-gray-900 text-right break-all">
+                          {String(value)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Section>
+
+              {/* Last seen */}
+              <Section icon={<Calendar className="w-3.5 h-3.5" />} title="Activity">
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-gray-500">First seen</span>
+                    <span className="text-gray-700">{formatDate(data.firstSeen)}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-gray-500">Last seen</span>
+                    <span className="text-gray-700">{formatDate(data.lastSeen)}</span>
+                  </div>
+                </div>
+              </Section>
+
+              {/* Anonymous IDs */}
+              <Section icon={<Link2 className="w-3.5 h-3.5" />} title={`Anonymous IDs (${data.anonymousIds.length})`}>
+                {data.anonymousIds.length === 0 ? (
+                  <p className="text-xs text-gray-400 italic">No anonymous IDs linked</p>
+                ) : (
+                  <div className="space-y-1.5">
+                    {data.anonymousIds.map(({ anonymousId, linkedAt }) => (
+                      <div key={anonymousId} className="flex items-center justify-between gap-2 rounded-lg bg-gray-50 px-3 py-2">
+                        <div className="min-w-0">
+                          <button
+                            onClick={() => onFilterEvents(anonymousId, 'anonymousId')}
+                            className="text-xs font-mono text-indigo-600 hover:underline truncate block text-left"
+                            title="Filter events by this anonymous ID"
+                          >
+                            {anonymousId}
+                          </button>
+                          <p className="text-xs text-gray-400 mt-0.5">linked {formatDate(linkedAt)}</p>
+                        </div>
+                        <ChevronRight className="w-3 h-3 text-gray-300 shrink-0" />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Section>
+
+              {/* Groups */}
+              <Section icon={<Users className="w-3.5 h-3.5" />} title={`Groups (${data.groups.length})`}>
+                {data.groups.length === 0 ? (
+                  <p className="text-xs text-gray-400 italic">Not in any groups</p>
+                ) : (
+                  <div className="space-y-2">
+                    {data.groups.map(({ groupId, traits, joinedAt }) => (
+                      <div key={groupId} className="rounded-lg border border-gray-100 overflow-hidden">
+                        <div className="px-3 py-2 bg-gray-50 flex items-center justify-between">
+                          <span className="text-xs font-medium text-gray-800 font-mono">{groupId}</span>
+                          <span className="text-xs text-gray-400">{new Date(joinedAt).toLocaleDateString()}</span>
+                        </div>
+                        {Object.keys(traits).length > 0 && (
+                          <div className="divide-y divide-gray-50">
+                            {Object.entries(traits).map(([k, v]) => (
+                              <div key={k} className="flex items-center justify-between px-3 py-1.5 text-xs">
+                                <span className="text-gray-500">{k}</span>
+                                <span className="text-gray-800 font-medium">{String(v)}</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Section>
+            </>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        <div className="px-5 py-3 border-t border-gray-100 flex gap-2">
+          <button
+            onClick={() => { onFilterEvents(userId, 'userId'); onClose() }}
+            className="flex-1 flex items-center justify-center gap-1.5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+          >
+            <Activity className="w-3.5 h-3.5" />
+            Show all events
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/ingestion/prisma/migrations/20260514000002_add_group_traits/migration.sql
+++ b/apps/ingestion/prisma/migrations/20260514000002_add_group_traits/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE ingestion.group_traits (
+    "id"           TEXT         NOT NULL,
+    "workspace_id" TEXT         NOT NULL,
+    "group_id"     TEXT         NOT NULL,
+    "user_id"      TEXT         NOT NULL,
+    "traits"       JSONB        NOT NULL DEFAULT '{}',
+    "source"       TEXT         NOT NULL,
+    "version"      TEXT         NOT NULL,
+    "created_at"   TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"   TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "group_traits_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "group_traits_workspace_id_group_id_user_id_key" ON ingestion.group_traits ("workspace_id", "group_id", "user_id");
+
+-- CreateIndex
+CREATE INDEX "group_traits_workspace_id_group_id_idx" ON ingestion.group_traits ("workspace_id", "group_id");
+
+-- CreateIndex
+CREATE INDEX "group_traits_workspace_id_user_id_idx" ON ingestion.group_traits ("workspace_id", "user_id");

--- a/apps/ingestion/prisma/schema.prisma
+++ b/apps/ingestion/prisma/schema.prisma
@@ -59,3 +59,20 @@ model AliasMap {
   @@index([workspaceId, userId])
   @@map("alias_map")
 }
+
+model GroupTrait {
+  id          String   @id @default(uuid())
+  workspaceId String   @map("workspace_id")
+  groupId     String   @map("group_id")
+  userId      String   @map("user_id")
+  traits      Json     @default("{}")
+  source      String
+  version     String
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@unique([workspaceId, groupId, userId])
+  @@index([workspaceId, groupId])
+  @@index([workspaceId, userId])
+  @@map("group_traits")
+}

--- a/apps/ingestion/src/ingestion/dto/group.dto.ts
+++ b/apps/ingestion/src/ingestion/dto/group.dto.ts
@@ -1,0 +1,46 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsUUID,
+  IsISO8601,
+  IsOptional,
+  IsObject,
+} from 'class-validator'
+
+export class GroupDto {
+  @IsString()
+  @IsNotEmpty()
+  groupId!: string
+
+  @IsString()
+  @IsNotEmpty()
+  userId!: string
+
+  @IsString()
+  @IsNotEmpty()
+  source!: string
+
+  @IsString()
+  @IsNotEmpty()
+  version!: string
+
+  @IsObject()
+  @IsOptional()
+  traits?: Record<string, unknown>
+
+  @IsUUID('4')
+  @IsOptional()
+  correlationId?: string
+
+  @IsUUID('4')
+  @IsOptional()
+  eventId?: string
+
+  @IsISO8601({ strict: true })
+  @IsOptional()
+  timestamp?: string
+
+  @IsObject()
+  @IsOptional()
+  context?: Record<string, unknown>
+}

--- a/apps/ingestion/src/ingestion/dto/ingest-event.dto.ts
+++ b/apps/ingestion/src/ingestion/dto/ingest-event.dto.ts
@@ -12,8 +12,8 @@ import {
 export class IngestEventDto {
   @IsString()
   @IsNotEmpty()
-  @Matches(/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)+$/, {
-    message: 'event must be dot notation lowercase, e.g. "order.created"',
+  @Matches(/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/, {
+    message: 'event must be dot notation lowercase, e.g. "product.added_to_cart"',
   })
   event!: string
 

--- a/apps/ingestion/src/ingestion/dto/page.dto.ts
+++ b/apps/ingestion/src/ingestion/dto/page.dto.ts
@@ -1,0 +1,55 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsUrl,
+  IsUUID,
+  IsISO8601,
+  IsOptional,
+  IsObject,
+} from 'class-validator'
+
+export class PageDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string
+
+  @IsUrl({ require_tld: false })
+  @IsOptional()
+  url?: string
+
+  @IsString()
+  @IsNotEmpty()
+  source!: string
+
+  @IsString()
+  @IsNotEmpty()
+  version!: string
+
+  @IsString()
+  @IsOptional()
+  userId?: string
+
+  @IsString()
+  @IsOptional()
+  anonymousId?: string
+
+  @IsString()
+  @IsOptional()
+  sessionId?: string
+
+  @IsUUID('4')
+  @IsOptional()
+  correlationId?: string
+
+  @IsUUID('4')
+  @IsOptional()
+  eventId?: string
+
+  @IsISO8601({ strict: true })
+  @IsOptional()
+  timestamp?: string
+
+  @IsObject()
+  @IsOptional()
+  context?: Record<string, unknown>
+}

--- a/apps/ingestion/src/ingestion/dto/query-events.dto.ts
+++ b/apps/ingestion/src/ingestion/dto/query-events.dto.ts
@@ -28,6 +28,14 @@ export class QueryEventsDto {
   search?: string
 
   @IsOptional()
+  @IsString()
+  userId?: string
+
+  @IsOptional()
+  @IsString()
+  anonymousId?: string
+
+  @IsOptional()
   @IsIn(['receivedAt', 'eventName'])
   sortBy?: 'receivedAt' | 'eventName' = 'receivedAt'
 }

--- a/apps/ingestion/src/ingestion/ingestion.controller.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.controller.spec.ts
@@ -9,6 +9,8 @@ const mockService = {
   ingestBatch: vi.fn(),
   identify: vi.fn(),
   alias: vi.fn(),
+  page: vi.fn(),
+  group: vi.fn(),
   findAll: vi.fn(),
   getThroughput: vi.fn(),
 }
@@ -167,6 +169,70 @@ describe('IngestionController', () => {
       await controller.alias(WORKSPACE_ID, HEADER_CORRELATION_ID, makeAlias() as any)
 
       expect(mockService.alias).toHaveBeenCalledWith(
+        expect.objectContaining({ correlationId: HEADER_CORRELATION_ID }),
+        WORKSPACE_ID,
+      )
+    })
+  })
+
+  describe('POST /events/page', () => {
+    const makePage = () => ({
+      name: 'Home',
+      url: 'https://example.com/',
+      source: 'web',
+      version: '1.0',
+      userId: 'user_123',
+    })
+
+    it('returns 202 with eventId and accepted status', async () => {
+      const eventId = randomUUID()
+      mockService.page.mockResolvedValue({ eventId, status: 'accepted' })
+
+      const result = await controller.page(WORKSPACE_ID, HEADER_CORRELATION_ID, makePage() as any)
+      expect(result).toEqual({ eventId, status: 'accepted' })
+    })
+
+    it('uses header correlationId when body does not include one', async () => {
+      mockService.page.mockResolvedValue({ eventId: randomUUID(), status: 'accepted' })
+
+      await controller.page(WORKSPACE_ID, HEADER_CORRELATION_ID, makePage() as any)
+
+      expect(mockService.page).toHaveBeenCalledWith(
+        expect.objectContaining({ correlationId: HEADER_CORRELATION_ID }),
+        WORKSPACE_ID,
+      )
+    })
+  })
+
+  describe('POST /events/group', () => {
+    const makeGroup = () => ({
+      groupId: 'acme-corp',
+      userId: 'user_123',
+      source: 'demo-store',
+      version: '1.0',
+      traits: { name: 'Acme Corp', plan: 'enterprise' },
+    })
+
+    it('returns 202 with groupId, userId and created status', async () => {
+      mockService.group.mockResolvedValue({ groupId: 'acme-corp', userId: 'user_123', status: 'created' })
+
+      const result = await controller.group(WORKSPACE_ID, HEADER_CORRELATION_ID, makeGroup() as any)
+      expect(result).toEqual({ groupId: 'acme-corp', userId: 'user_123', status: 'created' })
+    })
+
+    it('returns updated status when group membership already exists', async () => {
+      mockService.group.mockResolvedValue({ groupId: 'acme-corp', userId: 'user_123', status: 'updated' })
+
+      const result = await controller.group(WORKSPACE_ID, HEADER_CORRELATION_ID, makeGroup() as any)
+      expect(result.status).toBe('updated')
+    })
+
+    it('uses header correlationId when body does not include one', async () => {
+      mockService.group.mockResolvedValue({ groupId: 'acme-corp', userId: 'user_123', status: 'created' })
+
+      await controller.group(WORKSPACE_ID, HEADER_CORRELATION_ID, makeGroup() as any)
+
+      expect(mockService.group).toHaveBeenCalledWith(
         expect.objectContaining({ correlationId: HEADER_CORRELATION_ID }),
         WORKSPACE_ID,
       )

--- a/apps/ingestion/src/ingestion/ingestion.controller.ts
+++ b/apps/ingestion/src/ingestion/ingestion.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Body, HttpCode, Query, Headers } from '@nestjs/common'
+import { Controller, Post, Get, Body, HttpCode, Query, Headers, Param } from '@nestjs/common'
 import { WorkspaceId, CORRELATION_ID_HEADER } from '@flowmesh/nestjs-common'
 import { IngestionService } from './ingestion.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
@@ -13,6 +13,14 @@ import { ThroughputQueryDto } from './dto/throughput-query.dto'
 @Controller('events')
 export class IngestionController {
   constructor(private readonly ingestionService: IngestionService) {}
+
+  @Get('users/:userId')
+  getUserProfile(
+    @WorkspaceId() workspaceId: string,
+    @Param('userId') userId: string,
+  ) {
+    return this.ingestionService.getUserProfile(userId, workspaceId)
+  }
 
   @Get('throughput')
   getThroughput(

--- a/apps/ingestion/src/ingestion/ingestion.controller.ts
+++ b/apps/ingestion/src/ingestion/ingestion.controller.ts
@@ -5,6 +5,8 @@ import { IngestEventDto } from './dto/ingest-event.dto'
 import { IngestBatchDto } from './dto/ingest-batch.dto'
 import { IdentifyDto } from './dto/identify.dto'
 import { AliasDto } from './dto/alias.dto'
+import { PageDto } from './dto/page.dto'
+import { GroupDto } from './dto/group.dto'
 import { QueryEventsDto } from './dto/query-events.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
@@ -61,6 +63,28 @@ export class IngestionController {
   ) {
     const correlationId = dto.correlationId ?? headerCorrelationId
     return this.ingestionService.alias({ ...dto, correlationId }, workspaceId)
+  }
+
+  @Post('page')
+  @HttpCode(202)
+  async page(
+    @WorkspaceId() workspaceId: string,
+    @Headers(CORRELATION_ID_HEADER) headerCorrelationId: string,
+    @Body() dto: PageDto,
+  ) {
+    const correlationId = dto.correlationId ?? headerCorrelationId
+    return this.ingestionService.page({ ...dto, correlationId }, workspaceId)
+  }
+
+  @Post('group')
+  @HttpCode(202)
+  async group(
+    @WorkspaceId() workspaceId: string,
+    @Headers(CORRELATION_ID_HEADER) headerCorrelationId: string,
+    @Body() dto: GroupDto,
+  ) {
+    const correlationId = dto.correlationId ?? headerCorrelationId
+    return this.ingestionService.group({ ...dto, correlationId }, workspaceId)
   }
 
   @Post('batch')

--- a/apps/ingestion/src/ingestion/ingestion.service.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.spec.ts
@@ -9,6 +9,8 @@ import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 import { IdentifyDto } from './dto/identify.dto'
 import { AliasDto } from './dto/alias.dto'
+import { PageDto } from './dto/page.dto'
+import { GroupDto } from './dto/group.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
 const mockLogger = {
@@ -36,6 +38,7 @@ describe('IngestionService', () => {
     event: { create: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> }
     userTrait: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> }
     aliasMap: { findUnique: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> }
+    groupTrait: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> }
     $queryRaw: ReturnType<typeof vi.fn>
   }
   let rabbitmq: { publish: ReturnType<typeof vi.fn> }
@@ -55,6 +58,10 @@ describe('IngestionService', () => {
       aliasMap: {
         findUnique: vi.fn().mockResolvedValue(null),
         create: vi.fn().mockResolvedValue({}),
+      },
+      groupTrait: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        upsert: vi.fn().mockResolvedValue({}),
       },
       $queryRaw: vi.fn(),
     }
@@ -289,6 +296,109 @@ describe('IngestionService', () => {
       expect(call.eventName).toBe('user.aliased')
       expect(call.userId).toBe('user_123')
       expect(call.anonymousId).toBe('anon_abc')
+    })
+  })
+
+  describe('page', () => {
+    const makePage = (overrides: Partial<PageDto> = {}): PageDto & { correlationId: string } => ({
+      name: 'Home',
+      url: 'https://example.com/',
+      source: 'web',
+      version: '1.0',
+      userId: 'user_123',
+      correlationId: randomUUID(),
+      ...overrides,
+    })
+
+    it('returns accepted status for a valid page call', async () => {
+      const result = await service.page(makePage(), WORKSPACE_ID)
+      expect(result.status).toBe('accepted')
+    })
+
+    it('stores event name as page.viewed', async () => {
+      await service.page(makePage(), WORKSPACE_ID)
+      const call = prisma.event.create.mock.calls[0][0]
+      expect(call.data.eventName).toBe('page.viewed')
+    })
+
+    it('stores name and url in properties', async () => {
+      await service.page(makePage({ name: 'Checkout', url: 'https://example.com/checkout' }), WORKSPACE_ID)
+      const call = prisma.event.create.mock.calls[0][0]
+      expect(call.data.properties).toMatchObject({ name: 'Checkout', url: 'https://example.com/checkout' })
+    })
+
+    it('stores name in properties when url is omitted', async () => {
+      await service.page(makePage({ url: undefined }), WORKSPACE_ID)
+      const call = prisma.event.create.mock.calls[0][0]
+      expect(call.data.properties).toEqual({ name: 'Home' })
+    })
+
+    it('publishes page.viewed to RabbitMQ pipeline', async () => {
+      await service.page(makePage(), WORKSPACE_ID)
+      const message = rabbitmq.publish.mock.calls[0][0]
+      expect(message.payload.event).toBe('page.viewed')
+    })
+
+    it('returns duplicate when same eventId submitted twice', async () => {
+      redis.isEventProcessed.mockResolvedValue(true)
+      const result = await service.page(makePage({ eventId: randomUUID() }), WORKSPACE_ID)
+      expect(result.status).toBe('duplicate')
+    })
+  })
+
+  describe('group', () => {
+    const makeGroup = (overrides: Partial<GroupDto> = {}): GroupDto & { correlationId: string } => ({
+      groupId: 'acme-corp',
+      userId: 'user_123',
+      source: 'demo-store',
+      version: '1.0',
+      correlationId: randomUUID(),
+      traits: { name: 'Acme Corp', plan: 'enterprise' },
+      ...overrides,
+    })
+
+    it('returns created status when group membership does not exist yet', async () => {
+      prisma.groupTrait.findUnique.mockResolvedValue(null)
+      const result = await service.group(makeGroup(), WORKSPACE_ID)
+      expect(result).toEqual({ groupId: 'acme-corp', userId: 'user_123', status: 'created' })
+    })
+
+    it('returns updated status when group membership already exists', async () => {
+      prisma.groupTrait.findUnique.mockResolvedValue({ id: randomUUID() })
+      const result = await service.group(makeGroup(), WORKSPACE_ID)
+      expect(result.status).toBe('updated')
+    })
+
+    it('upserts group traits in the database', async () => {
+      const group = makeGroup()
+      await service.group(group, WORKSPACE_ID)
+      expect(prisma.groupTrait.upsert).toHaveBeenCalledOnce()
+      const call = prisma.groupTrait.upsert.mock.calls[0][0]
+      expect(call.where).toEqual({ workspaceId_groupId_userId: { workspaceId: WORKSPACE_ID, groupId: 'acme-corp', userId: 'user_123' } })
+      expect(call.create.traits).toEqual(group.traits)
+      expect(call.update.traits).toEqual(group.traits)
+    })
+
+    it('publishes group.identified event to RabbitMQ pipeline', async () => {
+      await service.group(makeGroup(), WORKSPACE_ID)
+      expect(rabbitmq.publish).toHaveBeenCalledOnce()
+      const message = rabbitmq.publish.mock.calls[0][0]
+      expect(message.payload.event).toBe('group.identified')
+      expect(message.payload.userId).toBe('user_123')
+      expect(message.meta.workspaceId).toBe(WORKSPACE_ID)
+    })
+
+    it('publishes group.identified to live event feed', async () => {
+      await service.group(makeGroup(), WORKSPACE_ID)
+      const call = pubsub.publishEvent.mock.calls[0][0]
+      expect(call.eventName).toBe('group.identified')
+      expect(call.userId).toBe('user_123')
+    })
+
+    it('stores empty traits object when traits are omitted', async () => {
+      await service.group(makeGroup({ traits: undefined }), WORKSPACE_ID)
+      const call = prisma.groupTrait.upsert.mock.calls[0][0]
+      expect(call.create.traits).toEqual({})
     })
   })
 

--- a/apps/ingestion/src/ingestion/ingestion.service.spec.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.spec.ts
@@ -37,7 +37,11 @@ describe('IngestionService', () => {
   let prisma: {
     event: { create: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> }
     userTrait: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> }
-    aliasMap: { findUnique: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> }
+    aliasMap: {
+      findUnique: ReturnType<typeof vi.fn>
+      findMany: ReturnType<typeof vi.fn>
+      create: ReturnType<typeof vi.fn>
+    }
     groupTrait: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> }
     $queryRaw: ReturnType<typeof vi.fn>
   }
@@ -57,6 +61,7 @@ describe('IngestionService', () => {
       },
       aliasMap: {
         findUnique: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn().mockResolvedValue([]),
         create: vi.fn().mockResolvedValue({}),
       },
       groupTrait: {
@@ -399,6 +404,123 @@ describe('IngestionService', () => {
       await service.group(makeGroup({ traits: undefined }), WORKSPACE_ID)
       const call = prisma.groupTrait.upsert.mock.calls[0][0]
       expect(call.create.traits).toEqual({})
+    })
+  })
+
+  describe('findAll', () => {
+    beforeEach(() => {
+      prisma.event.findMany.mockResolvedValue([])
+      prisma.event.count.mockResolvedValue(0)
+    })
+
+    it('returns events and total count', async () => {
+      const fakeEvent = { id: '1', eventId: randomUUID(), eventName: 'order.created', source: 'server', version: '1.0', correlationId: randomUUID(), userId: 'user_123', anonymousId: null, properties: {}, receivedAt: new Date() }
+      prisma.event.findMany.mockResolvedValue([fakeEvent])
+      prisma.event.count.mockResolvedValue(1)
+
+      const result = await service.findAll(WORKSPACE_ID, {})
+      expect(result.total).toBe(1)
+      expect(result.events).toHaveLength(1)
+      expect(result.limit).toBe(50)
+      expect(result.offset).toBe(0)
+    })
+
+    it('filters by event name when event param provided', async () => {
+      await service.findAll(WORKSPACE_ID, { event: 'order.created' })
+      const where = prisma.event.findMany.mock.calls[0][0].where
+      expect(where.AND).toContainEqual({ eventName: 'order.created' })
+    })
+
+    it('filters by source when source param provided', async () => {
+      await service.findAll(WORKSPACE_ID, { source: 'web' })
+      const where = prisma.event.findMany.mock.calls[0][0].where
+      expect(where.AND).toContainEqual({ source: 'web' })
+    })
+
+    it('filters by userId directly when no alias mapping exists', async () => {
+      prisma.aliasMap.findMany.mockResolvedValue([])
+      await service.findAll(WORKSPACE_ID, { userId: 'user_123' })
+      const where = prisma.event.findMany.mock.calls[0][0].where
+      expect(where.AND).toContainEqual({ userId: 'user_123' })
+    })
+
+    it('filters by anonymousId directly when no alias mapping exists', async () => {
+      prisma.aliasMap.findUnique.mockResolvedValue(null)
+      await service.findAll(WORKSPACE_ID, { anonymousId: 'anon_abc' })
+      const where = prisma.event.findMany.mock.calls[0][0].where
+      expect(where.AND).toContainEqual({ anonymousId: 'anon_abc' })
+    })
+
+    describe('identity stitching', () => {
+      it('expands userId filter to include pre-login events for linked anonymousIds', async () => {
+        prisma.aliasMap.findMany.mockResolvedValue([{ anonymousId: 'anon_abc' }])
+        await service.findAll(WORKSPACE_ID, { userId: 'user_123' })
+
+        const and = prisma.event.findMany.mock.calls[0][0].where.AND as unknown[]
+        const stitched = and.find((c) => typeof c === 'object' && 'OR' in (c as object)) as { OR: unknown[] }
+        expect(stitched.OR).toContainEqual({ userId: 'user_123' })
+        expect(stitched.OR).toContainEqual({ anonymousId: { in: ['anon_abc'] } })
+      })
+
+      it('expands anonymousId filter to include post-login events for linked userId', async () => {
+        prisma.aliasMap.findUnique.mockResolvedValue({ userId: 'user_123' })
+        await service.findAll(WORKSPACE_ID, { anonymousId: 'anon_abc' })
+
+        const and = prisma.event.findMany.mock.calls[0][0].where.AND as unknown[]
+        const stitched = and.find((c) => typeof c === 'object' && 'OR' in (c as object)) as { OR: unknown[] }
+        expect(stitched.OR).toContainEqual({ anonymousId: 'anon_abc' })
+        expect(stitched.OR).toContainEqual({ userId: 'user_123' })
+      })
+
+      it('includes all anonymousIds when a userId has multiple alias mappings', async () => {
+        prisma.aliasMap.findMany.mockResolvedValue([
+          { anonymousId: 'anon_device1' },
+          { anonymousId: 'anon_device2' },
+        ])
+        await service.findAll(WORKSPACE_ID, { userId: 'user_123' })
+
+        const and = prisma.event.findMany.mock.calls[0][0].where.AND as unknown[]
+        const stitched = and.find((c) => typeof c === 'object' && 'OR' in (c as object)) as { OR: unknown[] }
+        expect(stitched.OR).toContainEqual({ anonymousId: { in: ['anon_device1', 'anon_device2'] } })
+      })
+
+      it('looks up alias mapping scoped to the correct workspaceId', async () => {
+        await service.findAll(WORKSPACE_ID, { userId: 'user_123' })
+        expect(prisma.aliasMap.findMany).toHaveBeenCalledWith({
+          where: { workspaceId: WORKSPACE_ID, userId: 'user_123' },
+          select: { anonymousId: true },
+        })
+      })
+
+      it('looks up alias mapping scoped to the correct workspaceId for anonymousId filter', async () => {
+        await service.findAll(WORKSPACE_ID, { anonymousId: 'anon_abc' })
+        expect(prisma.aliasMap.findUnique).toHaveBeenCalledWith({
+          where: { workspaceId_anonymousId: { workspaceId: WORKSPACE_ID, anonymousId: 'anon_abc' } },
+          select: { userId: true },
+        })
+      })
+    })
+
+    it('applies case-insensitive search across eventName, source, and correlationId', async () => {
+      await service.findAll(WORKSPACE_ID, { search: 'checkout' })
+      const and = prisma.event.findMany.mock.calls[0][0].where.AND
+      const searchClause = and.find((c: { OR?: unknown }) => c.OR)
+      expect(searchClause.OR).toContainEqual({ eventName: { contains: 'checkout', mode: 'insensitive' } })
+      expect(searchClause.OR).toContainEqual({ source: { contains: 'checkout', mode: 'insensitive' } })
+      expect(searchClause.OR).toContainEqual({ correlationId: { contains: 'checkout', mode: 'insensitive' } })
+    })
+
+    it('respects limit and offset from query params', async () => {
+      await service.findAll(WORKSPACE_ID, { limit: 10, offset: 20 })
+      const call = prisma.event.findMany.mock.calls[0][0]
+      expect(call.take).toBe(10)
+      expect(call.skip).toBe(20)
+    })
+
+    it('returns limit and offset in the response', async () => {
+      const result = await service.findAll(WORKSPACE_ID, { limit: 25, offset: 50 })
+      expect(result.limit).toBe(25)
+      expect(result.offset).toBe(50)
     })
   })
 

--- a/apps/ingestion/src/ingestion/ingestion.service.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.ts
@@ -9,6 +9,8 @@ import { RedisPubSubService } from '../redis/redis-pubsub.service'
 import { IngestEventDto } from './dto/ingest-event.dto'
 import { IdentifyDto } from './dto/identify.dto'
 import { AliasDto } from './dto/alias.dto'
+import { PageDto } from './dto/page.dto'
+import { GroupDto } from './dto/group.dto'
 import { QueryEventsDto } from './dto/query-events.dto'
 import { ThroughputQueryDto } from './dto/throughput-query.dto'
 
@@ -37,6 +39,12 @@ export interface AliasResult {
   userId: string
   anonymousId: string
   status: 'created' | 'exists'
+}
+
+export interface GroupResult {
+  groupId: string
+  userId: string
+  status: 'created' | 'updated'
 }
 
 @Injectable()
@@ -118,46 +126,16 @@ export class IngestionService {
       },
     })
 
-    // Publish to pipeline queue
-    await this.rabbitmq.publish({
-      meta: {
-        messageId: randomUUID(),
-        correlationId: dto.correlationId,
-        timestamp: new Date().toISOString(),
-        source: 'ingestion',
-        version: '1.0',
-        workspaceId,
-      },
-      payload: {
-        eventId,
-        event: dto.event,
-        source: dto.source,
-        version: dto.version,
-        userId: dto.userId,
-        anonymousId: dto.anonymousId,
-        sessionId: dto.sessionId,
-        properties: dto.properties ?? {},
-        context: dto.context ?? {},
-        receivedAt: timestamp,
-      },
+    await this.publishToQueue(dto.correlationId, workspaceId, {
+      eventId, event: dto.event, source: dto.source, version: dto.version,
+      userId: dto.userId, anonymousId: dto.anonymousId, sessionId: dto.sessionId,
+      properties: dto.properties ?? {}, context: dto.context ?? {}, receivedAt: timestamp,
     })
 
     // Mark as processed after successful publish
     await this.redis.markEventProcessed(eventId)
 
-    // Publish to live event feed (fire-and-forget — never block ingestion for this)
-    this.pubsub.publishEvent({
-      id: eventId,
-      eventId,
-      eventName: dto.event,
-      source: dto.source,
-      userId: dto.userId ?? null,
-      anonymousId: dto.anonymousId ?? null,
-      correlationId: dto.correlationId,
-      properties: dto.properties ?? {},
-      receivedAt: timestamp,
-      workspaceId,
-    }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
+    this.publishToLiveFeed({ eventId, eventName: dto.event, source: dto.source, userId: dto.userId ?? null, anonymousId: dto.anonymousId ?? null, correlationId: dto.correlationId, properties: dto.properties ?? {}, receivedAt: timestamp, workspaceId })
 
     this.logger.info({ eventId, correlationId: dto.correlationId, workspaceId, event: dto.event }, 'event accepted')
 
@@ -188,41 +166,11 @@ export class IngestionService {
       })
     }
 
-    // Publish so pipelines can react to alias events (e.g. welcome sequence after signup)
-    await this.rabbitmq.publish({
-      meta: {
-        messageId: randomUUID(),
-        correlationId: dto.correlationId,
-        timestamp: new Date().toISOString(),
-        source: 'ingestion',
-        version: '1.0',
-        workspaceId,
-      },
-      payload: {
-        eventId,
-        event: 'user.aliased',
-        source: dto.source,
-        version: dto.version,
-        userId: dto.userId,
-        anonymousId: dto.anonymousId,
-        properties: { anonymousId: dto.anonymousId },
-        context: {},
-        receivedAt: timestamp,
-      },
+    await this.publishToQueue(dto.correlationId, workspaceId, {
+      eventId, event: 'user.aliased', source: dto.source, version: dto.version,
+      userId: dto.userId, anonymousId: dto.anonymousId, properties: { anonymousId: dto.anonymousId }, context: {}, receivedAt: timestamp,
     })
-
-    this.pubsub.publishEvent({
-      id: eventId,
-      eventId,
-      eventName: 'user.aliased',
-      source: dto.source,
-      userId: dto.userId,
-      anonymousId: dto.anonymousId,
-      correlationId: dto.correlationId,
-      properties: { anonymousId: dto.anonymousId },
-      receivedAt: timestamp,
-      workspaceId,
-    }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
+    this.publishToLiveFeed({ eventId, eventName: 'user.aliased', source: dto.source, userId: dto.userId, anonymousId: dto.anonymousId, correlationId: dto.correlationId, properties: { anonymousId: dto.anonymousId }, receivedAt: timestamp, workspaceId })
 
     this.logger.info(
       { userId: dto.userId, anonymousId: dto.anonymousId, workspaceId, correlationId: dto.correlationId },
@@ -246,69 +194,103 @@ export class IngestionService {
     const eventId = dto.eventId ?? randomUUID()
     const timestamp = dto.timestamp ?? new Date().toISOString()
 
-    const existing = await this.prisma.userTrait.findUnique({
-      where: { workspaceId_userId: { workspaceId, userId: dto.userId } },
-      select: { id: true },
+    const status = await this.upsertTraits({
+      find: () => this.prisma.userTrait.findUnique({
+        where: { workspaceId_userId: { workspaceId, userId: dto.userId } },
+        select: { id: true },
+      }),
+      upsert: () => this.prisma.userTrait.upsert({
+        where: { workspaceId_userId: { workspaceId, userId: dto.userId } },
+        create: { workspaceId, userId: dto.userId, anonymousId: dto.anonymousId ?? null, traits: (dto.traits ?? {}) as object, source: dto.source, version: dto.version },
+        update: { anonymousId: dto.anonymousId ?? null, traits: (dto.traits ?? {}) as object, source: dto.source, version: dto.version },
+      }),
     })
 
-    await this.prisma.userTrait.upsert({
-      where: { workspaceId_userId: { workspaceId, userId: dto.userId } },
-      create: {
-        workspaceId,
-        userId: dto.userId,
-        anonymousId: dto.anonymousId ?? null,
-        traits: (dto.traits ?? {}) as object,
-        source: dto.source,
-        version: dto.version,
-      },
-      update: {
-        anonymousId: dto.anonymousId ?? null,
-        traits: (dto.traits ?? {}) as object,
-        source: dto.source,
-        version: dto.version,
-      },
+    await this.publishToQueue(dto.correlationId, workspaceId, {
+      eventId, event: 'user.identified', source: dto.source, version: dto.version,
+      userId: dto.userId, anonymousId: dto.anonymousId, properties: dto.traits ?? {}, context: dto.context ?? {}, receivedAt: timestamp,
     })
-
-    // Publish to pipeline so identify calls can trigger rules (e.g. welcome Slack message)
-    await this.rabbitmq.publish({
-      meta: {
-        messageId: randomUUID(),
-        correlationId: dto.correlationId,
-        timestamp: new Date().toISOString(),
-        source: 'ingestion',
-        version: '1.0',
-        workspaceId,
-      },
-      payload: {
-        eventId,
-        event: 'user.identified',
-        source: dto.source,
-        version: dto.version,
-        userId: dto.userId,
-        anonymousId: dto.anonymousId,
-        properties: dto.traits ?? {},
-        context: dto.context ?? {},
-        receivedAt: timestamp,
-      },
-    })
-
-    // Publish to live feed so the dashboard shows identify calls
-    this.pubsub.publishEvent({
-      id: eventId,
-      eventId,
-      eventName: 'user.identified',
-      source: dto.source,
-      userId: dto.userId,
-      anonymousId: dto.anonymousId ?? null,
-      correlationId: dto.correlationId,
-      properties: dto.traits ?? {},
-      receivedAt: timestamp,
-      workspaceId,
-    }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
-
+    this.publishToLiveFeed({ eventId, eventName: 'user.identified', source: dto.source, userId: dto.userId, anonymousId: dto.anonymousId ?? null, correlationId: dto.correlationId, properties: dto.traits ?? {}, receivedAt: timestamp, workspaceId })
     this.logger.info({ userId: dto.userId, workspaceId, correlationId: dto.correlationId }, 'user identified')
+    return { userId: dto.userId, status }
+  }
 
-    return { userId: dto.userId, status: existing ? 'updated' : 'created' }
+  async page(
+    dto: PageDto & { correlationId: string },
+    workspaceId: string,
+  ): Promise<IngestResult> {
+    return this.ingest(
+      {
+        ...dto,
+        event: 'page.viewed',
+        properties: { name: dto.name, ...(dto.url ? { url: dto.url } : {}) },
+      },
+      workspaceId,
+    )
+  }
+
+  async group(
+    dto: GroupDto & { correlationId: string },
+    workspaceId: string,
+  ): Promise<GroupResult> {
+    const eventId = dto.eventId ?? randomUUID()
+    const timestamp = dto.timestamp ?? new Date().toISOString()
+
+    const status = await this.upsertTraits({
+      find: () => this.prisma.groupTrait.findUnique({
+        where: { workspaceId_groupId_userId: { workspaceId, groupId: dto.groupId, userId: dto.userId } },
+        select: { id: true },
+      }),
+      upsert: () => this.prisma.groupTrait.upsert({
+        where: { workspaceId_groupId_userId: { workspaceId, groupId: dto.groupId, userId: dto.userId } },
+        create: { workspaceId, groupId: dto.groupId, userId: dto.userId, traits: (dto.traits ?? {}) as object, source: dto.source, version: dto.version },
+        update: { traits: (dto.traits ?? {}) as object, source: dto.source, version: dto.version },
+      }),
+    })
+
+    await this.publishToQueue(dto.correlationId, workspaceId, {
+      eventId, event: 'group.identified', source: dto.source, version: dto.version,
+      userId: dto.userId, properties: { groupId: dto.groupId, ...(dto.traits ?? {}) }, context: dto.context ?? {}, receivedAt: timestamp,
+    })
+    this.publishToLiveFeed({ eventId, eventName: 'group.identified', source: dto.source, userId: dto.userId, anonymousId: null, correlationId: dto.correlationId, properties: { groupId: dto.groupId, ...(dto.traits ?? {}) }, receivedAt: timestamp, workspaceId })
+    this.logger.info({ groupId: dto.groupId, userId: dto.userId, workspaceId, correlationId: dto.correlationId }, 'group identified')
+    return { groupId: dto.groupId, userId: dto.userId, status }
+  }
+
+  // Shared helper — both identify() and group() follow the same find→upsert→status pattern
+  private async upsertTraits(ops: {
+    find: () => Promise<{ id: string } | null>
+    upsert: () => Promise<unknown>
+  }): Promise<'created' | 'updated'> {
+    const existing = await ops.find()
+    await ops.upsert()
+    return existing ? 'updated' : 'created'
+  }
+
+  // Shared helper — publish a payload to the pipeline exchange
+  private publishToQueue(
+    correlationId: string,
+    workspaceId: string,
+    payload: Record<string, unknown>,
+  ) {
+    return this.rabbitmq.publish({
+      meta: { messageId: randomUUID(), correlationId, timestamp: new Date().toISOString(), source: 'ingestion', version: '1.0', workspaceId },
+      payload,
+    })
+  }
+
+  // Shared helper — fire-and-forget publish to Redis pub/sub live feed
+  private publishToLiveFeed(event: {
+    eventId: string; eventName: string; source: string
+    userId?: string | null; anonymousId: string | null; correlationId: string
+    properties: Record<string, unknown>; receivedAt: string; workspaceId: string
+  }) {
+    this.pubsub.publishEvent({
+      id: event.eventId, eventId: event.eventId, eventName: event.eventName,
+      source: event.source, userId: event.userId ?? null, anonymousId: event.anonymousId,
+      correlationId: event.correlationId, properties: event.properties,
+      receivedAt: event.receivedAt, workspaceId: event.workspaceId,
+    }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
   }
 
   async getThroughput(

--- a/apps/ingestion/src/ingestion/ingestion.service.ts
+++ b/apps/ingestion/src/ingestion/ingestion.service.ts
@@ -19,6 +19,16 @@ export interface ThroughputBucket {
   count: number
 }
 
+export interface UserProfile {
+  userId: string
+  traits: Record<string, unknown>
+  anonymousIds: { anonymousId: string; linkedAt: string }[]
+  groups: { groupId: string; traits: Record<string, unknown>; joinedAt: string }[]
+  eventCount: number
+  firstSeen: string | null
+  lastSeen: string | null
+}
+
 const RANGE_CONFIG = {
   '1h':  { interval: "1 hour",   trunc: 'minute', buckets: 60 },
   '24h': { interval: "24 hours", trunc: 'hour',   buckets: 24 },
@@ -61,16 +71,47 @@ export class IngestionService {
     const limit = query.limit ?? 50
     const offset = query.offset ?? 0
 
-    const where: Record<string, unknown> = { workspaceId }
-    if (query.event) where['eventName'] = query.event
-    if (query.source) where['source'] = query.source
-    if (query.search) {
-      where['OR'] = [
-        { eventName: { contains: query.search, mode: 'insensitive' } },
-        { source: { contains: query.search, mode: 'insensitive' } },
-        { correlationId: { contains: query.search, mode: 'insensitive' } },
-      ]
+    const and: Prisma.EventWhereInput[] = [{ workspaceId }]
+    if (query.event) and.push({ eventName: query.event })
+    if (query.source) and.push({ source: query.source })
+
+    if (query.userId) {
+      // Identity stitching — include pre-login events for all anonymousIds linked to this userId
+      const aliases = await this.prisma.aliasMap.findMany({
+        where: { workspaceId, userId: query.userId },
+        select: { anonymousId: true },
+      })
+      const linkedAnonIds = aliases.map((a) => a.anonymousId)
+      and.push(
+        linkedAnonIds.length > 0
+          ? { OR: [{ userId: query.userId }, { anonymousId: { in: linkedAnonIds } }] }
+          : { userId: query.userId },
+      )
     }
+
+    if (query.anonymousId) {
+      // Identity stitching — include post-login events for the userId this anonymousId was aliased to
+      const alias = await this.prisma.aliasMap.findUnique({
+        where: { workspaceId_anonymousId: { workspaceId, anonymousId: query.anonymousId } },
+        select: { userId: true },
+      })
+      and.push(
+        alias
+          ? { OR: [{ anonymousId: query.anonymousId }, { userId: alias.userId }] }
+          : { anonymousId: query.anonymousId },
+      )
+    }
+
+    if (query.search) {
+      and.push({
+        OR: [
+          { eventName: { contains: query.search, mode: 'insensitive' } },
+          { source: { contains: query.search, mode: 'insensitive' } },
+          { correlationId: { contains: query.search, mode: 'insensitive' } },
+        ],
+      })
+    }
+    const where: Prisma.EventWhereInput = { AND: and }
 
     const [events, total] = await Promise.all([
       this.prisma.event.findMany({
@@ -166,6 +207,27 @@ export class IngestionService {
       })
     }
 
+    const isDuplicate = await this.redis.isEventProcessed(eventId)
+    if (!isDuplicate) {
+      await this.prisma.event.create({
+        data: {
+          workspaceId,
+          eventId,
+          correlationId: dto.correlationId,
+          eventName: 'user.aliased',
+          source: dto.source,
+          version: dto.version,
+          userId: dto.userId ?? null,
+          anonymousId: dto.anonymousId ?? null,
+          sessionId: null,
+          properties: { anonymousId: dto.anonymousId } as object,
+          context: {} as object,
+          receivedAt: new Date(),
+        },
+      })
+      await this.redis.markEventProcessed(eventId)
+    }
+
     await this.publishToQueue(dto.correlationId, workspaceId, {
       eventId, event: 'user.aliased', source: dto.source, version: dto.version,
       userId: dto.userId, anonymousId: dto.anonymousId, properties: { anonymousId: dto.anonymousId }, context: {}, receivedAt: timestamp,
@@ -205,6 +267,27 @@ export class IngestionService {
         update: { anonymousId: dto.anonymousId ?? null, traits: (dto.traits ?? {}) as object, source: dto.source, version: dto.version },
       }),
     })
+
+    const isDuplicate = await this.redis.isEventProcessed(eventId)
+    if (!isDuplicate) {
+      await this.prisma.event.create({
+        data: {
+          workspaceId,
+          eventId,
+          correlationId: dto.correlationId,
+          eventName: 'user.identified',
+          source: dto.source,
+          version: dto.version,
+          userId: dto.userId ?? null,
+          anonymousId: dto.anonymousId ?? null,
+          sessionId: null,
+          properties: (dto.traits ?? {}) as object,
+          context: (dto.context ?? {}) as object,
+          receivedAt: new Date(),
+        },
+      })
+      await this.redis.markEventProcessed(eventId)
+    }
 
     await this.publishToQueue(dto.correlationId, workspaceId, {
       eventId, event: 'user.identified', source: dto.source, version: dto.version,
@@ -247,6 +330,27 @@ export class IngestionService {
         update: { traits: (dto.traits ?? {}) as object, source: dto.source, version: dto.version },
       }),
     })
+
+    const isDuplicate = await this.redis.isEventProcessed(eventId)
+    if (!isDuplicate) {
+      await this.prisma.event.create({
+        data: {
+          workspaceId,
+          eventId,
+          correlationId: dto.correlationId,
+          eventName: 'group.identified',
+          source: dto.source,
+          version: dto.version,
+          userId: dto.userId ?? null,
+          anonymousId: null,
+          sessionId: null,
+          properties: { groupId: dto.groupId, ...(dto.traits ?? {}) } as object,
+          context: (dto.context ?? {}) as object,
+          receivedAt: new Date(),
+        },
+      })
+      await this.redis.markEventProcessed(eventId)
+    }
 
     await this.publishToQueue(dto.correlationId, workspaceId, {
       eventId, event: 'group.identified', source: dto.source, version: dto.version,
@@ -291,6 +395,53 @@ export class IngestionService {
       correlationId: event.correlationId, properties: event.properties,
       receivedAt: event.receivedAt, workspaceId: event.workspaceId,
     }).catch((err) => this.logger.warn({ err }, 'live event publish failed — non-critical'))
+  }
+
+  async getUserProfile(userId: string, workspaceId: string): Promise<UserProfile> {
+    const [traits, aliases, groups] = await Promise.all([
+      this.prisma.userTrait.findUnique({
+        where: { workspaceId_userId: { workspaceId, userId } },
+      }),
+      this.prisma.aliasMap.findMany({
+        where: { workspaceId, userId },
+        select: { anonymousId: true, createdAt: true },
+        orderBy: { createdAt: 'asc' },
+      }),
+      this.prisma.groupTrait.findMany({
+        where: { workspaceId, userId },
+        select: { groupId: true, traits: true, createdAt: true },
+        orderBy: { createdAt: 'asc' },
+      }),
+    ])
+
+    const anonIds = aliases.map((a) => a.anonymousId)
+    const eventWhere = {
+      workspaceId,
+      OR: [
+        { userId },
+        ...(anonIds.length > 0 ? [{ anonymousId: { in: anonIds } }] : []),
+      ],
+    }
+
+    const [eventCount, firstEvent, lastEvent] = await Promise.all([
+      this.prisma.event.count({ where: eventWhere }),
+      this.prisma.event.findFirst({ where: eventWhere, orderBy: { receivedAt: 'asc' }, select: { receivedAt: true } }),
+      this.prisma.event.findFirst({ where: eventWhere, orderBy: { receivedAt: 'desc' }, select: { receivedAt: true } }),
+    ])
+
+    return {
+      userId,
+      traits: (traits?.traits ?? {}) as Record<string, unknown>,
+      anonymousIds: aliases.map((a) => ({ anonymousId: a.anonymousId, linkedAt: a.createdAt.toISOString() })),
+      groups: groups.map((g) => ({
+        groupId: g.groupId,
+        traits: (g.traits ?? {}) as Record<string, unknown>,
+        joinedAt: g.createdAt.toISOString(),
+      })),
+      eventCount,
+      firstSeen: firstEvent?.receivedAt.toISOString() ?? null,
+      lastSeen: lastEvent?.receivedAt.toISOString() ?? null,
+    }
   }
 
   async getThroughput(

--- a/docs/sdk-contract.md
+++ b/docs/sdk-contract.md
@@ -16,6 +16,8 @@ Every SDK implements exactly these four methods. No SDK ships a subset. Future m
 | `identify(input)` | `POST /ingest/events/identify` | Store traits for a known user |
 | `alias(input)` | `POST /ingest/events/alias` | Link an anonymous visitor to a known user |
 | `batch(inputs[])` | `POST /ingest/events/batch` | Send multiple track events in one call |
+| `page(input)` | `POST /ingest/events/page` | Record a page view (auto-sets event to `page.viewed`) |
+| `group(input)` | `POST /ingest/events/group` | Associate a user with an organisation or account |
 
 ---
 
@@ -228,21 +230,60 @@ Coverage threshold: 80% statements, branches, and functions.
 
 ---
 
-## Planned Methods (not yet implemented)
+## page
 
-These will be added to all SDKs simultaneously when the backend endpoints ship:
+First-class page view. The `event` field is set to `page.viewed` automatically — callers provide the page title and optional URL instead.
 
-### page (post-launch v0.2)
-```
-page(input)  →  POST /ingest/events/page
-```
-First-class page view. Fields: `name` (page title, required), `url` (optional), plus all track fields except `event` (which is set to `page.viewed` automatically).
+**Input:**
 
-### group (post-launch v0.2)
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | ✅ | Page title, e.g. `"Checkout"`, `"Product Detail"` |
+| `url` | string | optional | Full page URL |
+| `source` | string | ✅ | Origin: `web`, `mobile`, etc. |
+| `version` | string | ✅ | Schema version |
+| `userId` | string | one-of | Required if `anonymousId` absent |
+| `anonymousId` | string | one-of | Required if `userId` absent |
+| `sessionId` | string | optional | |
+| `eventId` | UUID | optional | Idempotency key |
+| `timestamp` | ISO 8601 | optional | |
+| `context` | object | optional | |
+
+**Response:** same shape as `track` — `{ eventId, status: "accepted" | "duplicate" }`.
+
+---
+
+## group
+
+Associate a `userId` with an organisation or account. Subsequent calls for the same `groupId + userId` pair update the stored traits (upsert).
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `groupId` | string | ✅ | The organisation or account ID |
+| `userId` | string | ✅ | The user being associated with the group |
+| `source` | string | ✅ | |
+| `version` | string | ✅ | |
+| `traits` | object | optional | Group attributes: `name`, `plan`, `industry`, `size`, etc. |
+| `eventId` | UUID | optional | |
+| `timestamp` | ISO 8601 | optional | |
+| `context` | object | optional | |
+
+**Response:**
+
+```json
+{ "groupId": "acme-corp", "userId": "user_123", "status": "created" }
+{ "groupId": "acme-corp", "userId": "user_123", "status": "updated" }
 ```
-group(input)  →  POST /ingest/events/group
-```
-Associate a userId with an organisation or account. Fields: `userId` (required), `groupId` (required), `traits` (optional — company name, plan, size, etc.).
+
+`created` on first call for this groupId + userId pair. `updated` on all subsequent calls.
+
+---
+
+## Planned Methods (post-launch)
+
+Future methods added here before implementation begins:
 
 ---
 

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowmesh-node",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Official Node.js SDK for FlowMesh — self-hostable event pipeline platform",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk-node/src/client.spec.ts
+++ b/packages/sdk-node/src/client.spec.ts
@@ -256,6 +256,121 @@ describe('FlowMesh', () => {
     })
   })
 
+  describe('page', () => {
+    const VALID_PAGE = { name: 'Home', url: 'https://example.com/', source: 'web', version: '1.0', userId: 'user_123' }
+
+    beforeEach(() => {
+      vi.stubGlobal('fetch', makeFetch(202, { status: 'accepted', eventId: 'evt-page-1' }))
+    })
+
+    it('posts to /ingest/events/page with api key header', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test', host: 'http://localhost:3000' })
+      const result = await client.page(VALID_PAGE)
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:3000/ingest/events/page',
+        expect.objectContaining({ headers: expect.objectContaining({ 'x-api-key': 'fm_test' }) }),
+      )
+      expect(result).toEqual({ status: 'accepted', eventId: 'evt-page-1' })
+    })
+
+    it('throws when name is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.page({ ...VALID_PAGE, name: '' })).rejects.toThrow('name is required')
+    })
+
+    it('throws when source is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.page({ ...VALID_PAGE, source: '' })).rejects.toThrow('source is required')
+    })
+
+    it('throws when neither userId nor anonymousId provided', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.page({ ...VALID_PAGE, userId: undefined })).rejects.toThrow('userId or anonymousId is required')
+    })
+
+    it('retries on 500 and succeeds', async () => {
+      let calls = 0
+      vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+        calls++
+        if (calls < 2) return Promise.resolve({ status: 500, json: () => Promise.resolve({}) })
+        return Promise.resolve({ status: 202, json: () => Promise.resolve({ status: 'accepted', eventId: 'evt-1' }) })
+      }))
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      const result = await client.page(VALID_PAGE)
+      expect(calls).toBe(2)
+      expect(result.status).toBe('accepted')
+    })
+
+    it('throws immediately on 4xx without retrying', async () => {
+      vi.stubGlobal('fetch', makeFetch(400, {}))
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      await expect(client.page(VALID_PAGE)).rejects.toThrow('status 400')
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('group', () => {
+    const VALID_GROUP = { groupId: 'acme-corp', userId: 'user_123', source: 'server', version: '1.0', traits: { plan: 'enterprise' } }
+
+    beforeEach(() => {
+      vi.stubGlobal('fetch', makeFetch(202, { groupId: 'acme-corp', userId: 'user_123', status: 'created' }))
+    })
+
+    it('posts to /ingest/events/group with api key header', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test', host: 'http://localhost:3000' })
+      const result = await client.group(VALID_GROUP)
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:3000/ingest/events/group',
+        expect.objectContaining({ headers: expect.objectContaining({ 'x-api-key': 'fm_test' }) }),
+      )
+      expect(result).toEqual({ groupId: 'acme-corp', userId: 'user_123', status: 'created' })
+    })
+
+    it('returns updated status when group membership already exists', async () => {
+      vi.stubGlobal('fetch', makeFetch(202, { groupId: 'acme-corp', userId: 'user_123', status: 'updated' }))
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      const result = await client.group(VALID_GROUP)
+      expect(result.status).toBe('updated')
+    })
+
+    it('throws when groupId is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.group({ ...VALID_GROUP, groupId: '' })).rejects.toThrow('groupId is required')
+    })
+
+    it('throws when userId is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.group({ ...VALID_GROUP, userId: '' })).rejects.toThrow('userId is required')
+    })
+
+    it('throws when source is missing', async () => {
+      const client = new FlowMesh({ apiKey: 'fm_test' })
+      await expect(client.group({ ...VALID_GROUP, source: '' })).rejects.toThrow('source is required')
+    })
+
+    it('retries on 500 and succeeds', async () => {
+      let calls = 0
+      vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+        calls++
+        if (calls < 2) return Promise.resolve({ status: 500, json: () => Promise.resolve({}) })
+        return Promise.resolve({ status: 202, json: () => Promise.resolve({ groupId: 'acme-corp', userId: 'user_123', status: 'created' }) })
+      }))
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      const result = await client.group(VALID_GROUP)
+      expect(calls).toBe(2)
+      expect(result.status).toBe('created')
+    })
+
+    it('throws immediately on 4xx without retrying', async () => {
+      vi.stubGlobal('fetch', makeFetch(401, {}))
+      const client = new FlowMesh({ apiKey: 'fm_test', maxRetries: 3 })
+      await expect(client.group(VALID_GROUP)).rejects.toThrow('status 401')
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('batch', () => {
     beforeEach(() => {
       vi.stubGlobal('fetch', makeFetch(202, { accepted: 2, duplicates: 0, results: [] }))

--- a/packages/sdk-node/src/client.ts
+++ b/packages/sdk-node/src/client.ts
@@ -1,5 +1,5 @@
 import { withRetry } from './retry.js'
-import type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, AliasInput, AliasResult } from './types.js'
+import type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, AliasInput, AliasResult, PageInput, GroupInput, GroupResult } from './types.js'
 
 const DEFAULT_HOST = 'http://localhost:3000'
 const DEFAULT_MAX_RETRIES = 3
@@ -50,6 +50,32 @@ export class FlowMesh {
     return withRetry(async () => {
       const res = await this.post('/ingest/events/alias', input)
       const body = await res.json() as AliasResult
+      return { status: res.status, body }
+    }, this.maxRetries)
+  }
+
+  async page(input: PageInput): Promise<TrackResult> {
+    if (!input.name) throw new Error('FlowMesh: name is required for page')
+    if (!input.source) throw new Error('FlowMesh: source is required')
+    if (!input.version) throw new Error('FlowMesh: version is required')
+    if (!input.userId && !input.anonymousId) throw new Error('FlowMesh: userId or anonymousId is required')
+
+    return withRetry(async () => {
+      const res = await this.post('/ingest/events/page', input)
+      const body = await res.json() as TrackResult
+      return { status: res.status, body }
+    }, this.maxRetries)
+  }
+
+  async group(input: GroupInput): Promise<GroupResult> {
+    if (!input.groupId) throw new Error('FlowMesh: groupId is required for group')
+    if (!input.userId) throw new Error('FlowMesh: userId is required for group')
+    if (!input.source) throw new Error('FlowMesh: source is required')
+    if (!input.version) throw new Error('FlowMesh: version is required')
+
+    return withRetry(async () => {
+      const res = await this.post('/ingest/events/group', input)
+      const body = await res.json() as GroupResult
       return { status: res.status, body }
     }, this.maxRetries)
   }

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -1,2 +1,2 @@
 export { FlowMesh } from './client.js'
-export type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, AliasInput, AliasResult, FlowMeshError } from './types.js'
+export type { FlowMeshOptions, TrackInput, TrackResult, BatchResult, IdentifyInput, IdentifyResult, AliasInput, AliasResult, PageInput, GroupInput, GroupResult, FlowMeshError } from './types.js'

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -63,6 +63,36 @@ export interface AliasResult {
   status: 'created' | 'exists'
 }
 
+export interface PageInput {
+  name: string
+  url?: string
+  source: string
+  version: string
+  userId?: string
+  anonymousId?: string
+  sessionId?: string
+  eventId?: string
+  timestamp?: string
+  context?: Record<string, unknown>
+}
+
+export interface GroupInput {
+  groupId: string
+  userId: string
+  source: string
+  version: string
+  traits?: Record<string, unknown>
+  eventId?: string
+  timestamp?: string
+  context?: Record<string, unknown>
+}
+
+export interface GroupResult {
+  groupId: string
+  userId: string
+  status: 'created' | 'updated'
+}
+
 export interface FlowMeshError extends Error {
   status?: number
 }


### PR DESCRIPTION
## Summary

- **Identity stitching** — `GET /events` now resolves the full user journey via `alias_map`. Filtering by `userId` includes pre-login anonymous events; filtering by `anonymousId` includes post-login events. Both directions work symmetrically.
- **User profile endpoint** — `GET /events/users/:userId` returns traits, linked anonymous IDs, group memberships, event count, first/last seen (all with identity stitching applied).
- **Events page filter bar** — user ID / anonymous ID (click-to-filter from any row), event name, source, clear-all. Active anonymousId filter prefers showing anonymousId in the user column for events that carry both IDs (alias/identify events).
- **User profile drawer** — hover over any userId in the Events table to reveal a profile icon; clicking opens a slide-in panel with traits, anonymous IDs, groups, event stats, and a "show all events" button.
- **Event persistence fix** — `identify()`, `alias()`, and `group()` now write a row to the events table, making them queryable via `GET /events` (previously they only appeared in the live feed).
- **Event name regex fix** — underscores now allowed in event name segments (`product.added_to_cart` was previously rejected).
- **18 new unit tests** — cover `findAll` with all filter params, identity stitching in both directions, multi-device alias expansion, workspace scoping.

## Test plan

- [ ] Sign in on demo store → Events page shows `user.identified`, `user.aliased`, `group.identified` rows
- [ ] Click anonymous ID row → filter shows pre-login events only (no post-login events without identity stitching)
- [ ] Click same anonymous ID → filter shows full journey (pre-login + post-login) after this PR
- [ ] Click real userId → filter shows full journey including pre-login anonymous events
- [ ] Hover over a userId → profile icon appears → click → drawer opens with traits, groups, anon IDs
- [ ] "Show all events" in drawer applies identity-stitched filter and closes drawer
- [ ] Event name filter, source filter, clear-all all work independently and in combination
- [ ] `pnpm test` — 336 tests pass